### PR TITLE
[#84] 회원 서비스 비즈니스 로직의 트랜잭션 격리 수준 조정

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/user/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/user/service/AuthenticationServiceImpl.java
@@ -53,6 +53,7 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
     public User signUpUser(SignUpForm signUpForm) {
         User user = User.from(signUpForm, passwordEncoder);
 
+        validatePassword(user.getPassword(), signUpForm.getPasswordConfirm());
         validateNotDuplicateUser(signUpForm.getUsername(), signUpForm.getEmail(), signUpForm.getPhone());
 
         return userRepository.save(user);
@@ -69,18 +70,24 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
     }
 
     @Override
+    @Transactional(isolation = REPEATABLE_READ, timeout = 10)
     public void updateEmail(Long id, EmailRequestDto emailRequestDto) {
         User user = userService.getUser(id);
 
         validatePassword(user.getPassword(), emailRequestDto.getPassword());
+        checkEmail(emailRequestDto.getEmail());
+
         user.updateEmail(emailRequestDto.getEmail());
     }
 
     @Override
+    @Transactional(isolation = REPEATABLE_READ, timeout = 10)
     public void updatePhone(Long id, PhoneRequestDto phoneRequestDto) {
         User user = userService.getUser(id);
 
         validatePassword(user.getPassword(), phoneRequestDto.getPassword());
+        checkPhone(phoneRequestDto.getPhone());
+
         user.updatePhone(phoneRequestDto.getPhone());
     }
 

--- a/src/main/java/com/firstone/greenjangteo/user/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/user/service/AuthenticationServiceImpl.java
@@ -30,14 +30,14 @@ import javax.persistence.EntityNotFoundException;
 import static com.firstone.greenjangteo.user.excpeption.message.DuplicateExceptionMessage.*;
 import static com.firstone.greenjangteo.user.excpeption.message.NotFoundExceptionMessage.EMAIL_NOT_FOUND_EXCEPTION;
 import static com.firstone.greenjangteo.user.excpeption.message.NotFoundExceptionMessage.USERNAME_NOT_FOUND_EXCEPTION;
-import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
-import static org.springframework.transaction.annotation.Isolation.REPEATABLE_READ;
+import static org.springframework.transaction.annotation.Isolation.*;
 
 /**
  * 인증이 필요한 서비스
  */
 @Service
 @RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, timeout = 10)
 public class AuthenticationServiceImpl implements AuthenticationService, UserDetailsService {
     private final UserService userService;
     private final UserRepository userRepository;
@@ -49,7 +49,7 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
     }
 
     @Override
-    @Transactional(isolation = REPEATABLE_READ, timeout = 20)
+    @Transactional(isolation = SERIALIZABLE, timeout = 20)
     public User signUpUser(SignUpForm signUpForm) {
         User user = User.from(signUpForm, passwordEncoder);
 
@@ -59,7 +59,6 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
     }
 
     @Override
-    @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
     public User signInUser(SignInForm signInForm) {
         User signedUpUser = getUserFromEmailOrUsername(signInForm.getEmailOrUsername());
 


### PR DESCRIPTION
## resolve #84

## 변경사항
- 회원가입 로직의 트랜잭션 격리 수준을 REPEATABLE_READ에서 SERIALIZABLE로 격상
    - 이메일 주소, 사용자 이름, 전화번호의 중복 검사 수행 중 다른 사용자가 동일 데이터로 가입하는 문제 방지
- 로그인 로직에 로그인 시간 업데이트 작업이 추가되었으므로 readOnly 속성 제거
- 누락된 전체 메서드의 트랜잭션 격리 수준 설정 설정(READ_COMMITTED) 추가
- 이메일 주소 변경과 전화번호 변경 로직에 중복된 이메일 주소와 전화번호에 대한 검사 과정 추가
    - 트랜잭션 격리 수준을 REPEATABLE_READ로 격상
        - 회원 데이터의 일관성 보장
        - 중복 검사 도중 다른 사용자가 가입한 경우(phantom read) 변경 불가