### PR TITLE
[#95] 가게 엔티티와 상품 엔티티 매핑

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/product/domain/dto/ProductDto.java
+++ b/src/main/java/com/firstone/greenjangteo/product/domain/dto/ProductDto.java
@@ -1,7 +1,6 @@
 package com.firstone.greenjangteo.product.domain.dto;
 
 import com.firstone.greenjangteo.product.domain.model.Product;
-import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -13,7 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ProductDto {
     private Long productId;
-    private Store sellerId;
+    private Long sellerId;
     private String name;
     private Integer price;
     private String description;
@@ -26,7 +25,7 @@ public class ProductDto {
     public static ProductDto of(Product product) {
         return ProductDto.builder()
                 .productId(product.getId())
-                .sellerId(product.getStore())
+                .sellerId(product.getStore().getSellerId())
                 .name(product.getName())
                 .price(product.getPrice())
                 .inventory(product.getInventory())

--- a/src/main/java/com/firstone/greenjangteo/product/domain/model/Product.java
+++ b/src/main/java/com/firstone/greenjangteo/product/domain/model/Product.java
@@ -1,13 +1,14 @@
 package com.firstone.greenjangteo.product.domain.model;
 
-import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
 import com.firstone.greenjangteo.product.domain.dto.ProductDto;
+import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -23,8 +24,12 @@ public class Product {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id; //상품코드
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
     private Store store;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ProductImage> productImages;
 
     @Column(nullable = false, length = 20)
     private String name; //상품명
@@ -47,9 +52,9 @@ public class Product {
     @LastModifiedDate
     private LocalDateTime modifiedAt;
 
-    public static Product addProduct(ProductDto productDto) {
+    public static Product addProduct(ProductDto productDto, Store store) {
         return Product.builder()
-                .store(productDto.getSellerId())
+                .store(store)
                 .name(productDto.getName())
                 .averageScore(productDto.getAverageScore())
                 .description(productDto.getDescription())

--- a/src/main/java/com/firstone/greenjangteo/product/service/ProductService.java
+++ b/src/main/java/com/firstone/greenjangteo/product/service/ProductService.java
@@ -10,6 +10,8 @@ import com.firstone.greenjangteo.product.exception.ProductException;
 import com.firstone.greenjangteo.product.repository.CategoryRepository;
 import com.firstone.greenjangteo.product.repository.ProductImageRepository;
 import com.firstone.greenjangteo.product.repository.ProductRepository;
+import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
+import com.firstone.greenjangteo.user.domain.store.service.StoreService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -28,19 +30,22 @@ public class ProductService {
 
     private final ProductImageService productImageService;
     private final CategoryService categoryService;
+    private final StoreService storeService;
 
     private final ProductRepository productRepository;
     private final ProductImageRepository productImageRepository;
     private final CategoryRepository categoryRepository;
 
     public Map<String, Object> saveProduct(ProductDto productDto, List<String> productImageUrlList, String productImageLocation) throws Exception {
-        Product product = Product.addProduct(productDto);
-        productRepository.save(product);
+        Store store = storeService.getStore(productDto.getSellerId());
+        Product product = Product.addProduct(productDto, store);
 
         for (int i = 0; i < productImageUrlList.size(); i++) {
             ProductImage productImage = ProductImage.saveProductImage(product, productImageUrlList.get(i), i);
             productImageService.saveProductImage(product, productImage, productImageUrlList.get(i), i, productImageLocation);
         }
+
+        productRepository.save(product);
 
         Map<String, Object> result = new HashMap<>();
         result.put("productId", product.getId());

--- a/src/main/java/com/firstone/greenjangteo/user/domain/store/controller/StoreController.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/store/controller/StoreController.java
@@ -1,6 +1,7 @@
 package com.firstone.greenjangteo.user.domain.store.controller;
 
-import com.firstone.greenjangteo.user.domain.store.dto.StoreDto;
+import com.firstone.greenjangteo.user.domain.store.dto.StoreRequestDto;
+import com.firstone.greenjangteo.user.domain.store.dto.StoreResponseDto;
 import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
 import com.firstone.greenjangteo.user.domain.store.service.StoreService;
 import io.swagger.annotations.ApiOperation;
@@ -30,11 +31,11 @@ public class StoreController {
     @ApiOperation(value = GET_STORE, notes = GET_STORE_DESCRIPTION)
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @GetMapping("/{userId}")
-    public ResponseEntity<StoreDto> getStore
+    public ResponseEntity<StoreResponseDto> getStore
             (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = "1") String userId) {
         Store store = storeService.getStore(Long.parseLong(userId));
 
-        return ResponseEntity.status(HttpStatus.OK).body(StoreDto.from(store));
+        return ResponseEntity.status(HttpStatus.OK).body(StoreResponseDto.from(store));
     }
 
     @ApiOperation(value = UPDATE_STORE, notes = UPDATE_STORE_DESCRIPTION)
@@ -42,8 +43,8 @@ public class StoreController {
     @PutMapping("/{userId}")
     public ResponseEntity<Void> updateStore
             (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = "1") String userId,
-             @RequestBody @ApiParam(value = UPDATE_STORE_FORM) StoreDto storeDto) {
-        storeService.updateStore(Long.parseLong(userId), storeDto);
+             @RequestBody @ApiParam(value = UPDATE_STORE_FORM) StoreRequestDto storeRequestDto) {
+        storeService.updateStore(Long.parseLong(userId), storeRequestDto);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/com/firstone/greenjangteo/user/domain/store/dto/StoreProductDto.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/store/dto/StoreProductDto.java
@@ -1,0 +1,31 @@
+package com.firstone.greenjangteo.user.domain.store.dto;
+
+import com.firstone.greenjangteo.product.domain.model.Product;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class StoreProductDto {
+    private String productName;
+    private int price;
+    private String imageUrl;
+    private int averageScore;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static StoreProductDto from(Product product) {
+        return StoreProductDto.builder()
+                .productName(product.getName())
+                .price(product.getPrice())
+                .imageUrl(product.getProductImages().get(0).getUrl())
+                .averageScore(product.getAverageScore())
+                .createdAt(product.getCreatedAt())
+                .modifiedAt(product.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/user/domain/store/dto/StoreRequestDto.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/store/dto/StoreRequestDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-public class StoreDto {
+public class StoreRequestDto {
     private static final String STORE_NAME_VALUE = "가게 이름";
     private static final String STORE_NAME_EXAMPLE = "친환경 스토어";
 
@@ -21,7 +21,6 @@ public class StoreDto {
     private static final String IMAGE_URL_EXAMPLE
             = "https://test-images-bucket.s3.us-west-1.amazonaws.com/images/sample1.jpg";
 
-
     @ApiModelProperty(value = STORE_NAME_VALUE, example = STORE_NAME_EXAMPLE)
     private String storeName;
 
@@ -31,11 +30,7 @@ public class StoreDto {
     @ApiModelProperty(value = IMAGE_URL_VALUE, example = IMAGE_URL_EXAMPLE)
     private String imageUrl;
 
-    public static StoreDto of(String storeName, String description, String imageUrl) {
-        return new StoreDto(storeName, description, imageUrl);
-    }
-
-    public static StoreDto from(Store store) {
-        return new StoreDto(store.getStoreName().getValue(), store.getDescription(), store.getImageUrl());
+    public static StoreRequestDto from(Store store) {
+        return new StoreRequestDto(store.getStoreName().getValue(), store.getDescription(), store.getImageUrl());
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/user/domain/store/dto/StoreResponseDto.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/store/dto/StoreResponseDto.java
@@ -1,0 +1,46 @@
+package com.firstone.greenjangteo.user.domain.store.dto;
+
+import com.firstone.greenjangteo.product.domain.model.Product;
+import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class StoreResponseDto {
+    private String storeName;
+    private String description;
+    private String imageUrl;
+    private List<StoreProductDto> storeProductDtos;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static StoreResponseDto from(Store store) {
+        List<StoreProductDto> storeProductDtos = Optional.ofNullable(store.getProducts())
+                .map(StoreResponseDto::transferStoreProductsToDto)
+                .orElse(new ArrayList<>());
+
+        return StoreResponseDto.builder()
+                .storeName(store.getStoreName().getValue())
+                .description(store.getDescription())
+                .imageUrl(store.getImageUrl())
+                .storeProductDtos(storeProductDtos)
+                .createdAt(store.getCreatedAt())
+                .modifiedAt(store.getModifiedAt())
+                .build();
+    }
+
+    private static List<StoreProductDto> transferStoreProductsToDto(List<Product> storeProducts) {
+        return storeProducts.stream()
+                .map(StoreProductDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/user/domain/store/model/entity/Store.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/store/model/entity/Store.java
@@ -1,14 +1,18 @@
 package com.firstone.greenjangteo.user.domain.store.model.entity;
 
 import com.firstone.greenjangteo.audit.BaseEntity;
-import com.firstone.greenjangteo.user.domain.store.dto.StoreDto;
+import com.firstone.greenjangteo.product.domain.model.Product;
+import com.firstone.greenjangteo.user.domain.store.dto.StoreRequestDto;
 import com.firstone.greenjangteo.user.domain.store.model.StoreName;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 import java.util.Objects;
+
+import static javax.persistence.CascadeType.*;
 
 @Entity(name = "store")
 @Table(name = "store")
@@ -27,6 +31,9 @@ public class Store extends BaseEntity {
 
     @Column
     private String imageUrl;
+
+    @OneToMany(mappedBy = "store", cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Product> products;
 
     private Store(Long userId, String storeName) {
         sellerId = userId;
@@ -51,9 +58,9 @@ public class Store extends BaseEntity {
         return Objects.hash(sellerId, storeName, description, imageUrl);
     }
 
-    public void update(StoreDto storeDto) {
-        storeName = StoreName.of(storeDto.getStoreName());
-        description = storeDto.getDescription();
-        imageUrl = storeDto.getImageUrl();
+    public void update(StoreRequestDto storeRequestDto) {
+        storeName = StoreName.of(storeRequestDto.getStoreName());
+        description = storeRequestDto.getDescription();
+        imageUrl = storeRequestDto.getImageUrl();
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/user/domain/store/service/StoreService.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/store/service/StoreService.java
@@ -1,6 +1,6 @@
 package com.firstone.greenjangteo.user.domain.store.service;
 
-import com.firstone.greenjangteo.user.domain.store.dto.StoreDto;
+import com.firstone.greenjangteo.user.domain.store.dto.StoreRequestDto;
 import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
 
 public interface StoreService {
@@ -8,7 +8,7 @@ public interface StoreService {
 
     Store getStore(Long userId);
 
-    void updateStore(Long userId, StoreDto storeDto);
+    void updateStore(Long userId, StoreRequestDto storeRequestDto);
 
     void deleteStore(long id);
 }

--- a/src/main/java/com/firstone/greenjangteo/user/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/store/service/StoreServiceImpl.java
@@ -1,6 +1,6 @@
 package com.firstone.greenjangteo.user.domain.store.service;
 
-import com.firstone.greenjangteo.user.domain.store.dto.StoreDto;
+import com.firstone.greenjangteo.user.domain.store.dto.StoreRequestDto;
 import com.firstone.greenjangteo.user.domain.store.exception.general.DuplicateStoreNameException;
 import com.firstone.greenjangteo.user.domain.store.model.StoreName;
 import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
@@ -37,9 +37,9 @@ public class StoreServiceImpl implements StoreService {
     }
 
     @Override
-    public void updateStore(Long userId, StoreDto storeDto) {
+    public void updateStore(Long userId, StoreRequestDto storeRequestDto) {
         Store store = getStore(userId);
-        store.update(storeDto);
+        store.update(storeRequestDto);
     }
 
     @Override

--- a/src/test/java/com/firstone/greenjangteo/user/domain/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/user/domain/store/controller/StoreControllerTest.java
@@ -1,7 +1,7 @@
 package com.firstone.greenjangteo.user.domain.store.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.firstone.greenjangteo.user.domain.store.dto.StoreDto;
+import com.firstone.greenjangteo.user.domain.store.dto.StoreRequestDto;
 import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
 import com.firstone.greenjangteo.user.domain.store.service.StoreService;
 import com.firstone.greenjangteo.user.domain.store.testutil.TestObjectFactory;
@@ -44,8 +44,8 @@ class StoreControllerTest {
     private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @DisplayName("판매자의 ID를 통해 자신의 가게 정보를 조회할 수 있다.")
-    @Test
     @WithMockUser
+    @Test
     void getStore() throws Exception {
         // given
         Store store = TestObjectFactory.createStore(1L, STORE_NAME1, DESCRIPTION1, IMAGE_URL1);
@@ -65,12 +65,12 @@ class StoreControllerTest {
         // given
         Store store = TestObjectFactory.createStore(1L, STORE_NAME1, DESCRIPTION1, IMAGE_URL1);
 
-        StoreDto storeDto = StoreDto.of(STORE_NAME1, DESCRIPTION1, IMAGE_URL1);
+        StoreRequestDto storeRequestDto = new StoreRequestDto(STORE_NAME1, DESCRIPTION1, IMAGE_URL1);
 
         // when, then
         mockMvc.perform(put("/stores/{userId}", store.getSellerId())
                         .with(csrf())
-                        .content(objectMapper.writeValueAsString(storeDto))
+                        .content(objectMapper.writeValueAsString(storeRequestDto))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isNoContent());

--- a/src/test/java/com/firstone/greenjangteo/user/domain/store/testutil/TestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/user/domain/store/testutil/TestObjectFactory.java
@@ -1,15 +1,26 @@
 package com.firstone.greenjangteo.user.domain.store.testutil;
 
-import com.firstone.greenjangteo.user.domain.store.dto.StoreDto;
+import com.firstone.greenjangteo.product.domain.model.Product;
+import com.firstone.greenjangteo.user.domain.store.dto.StoreRequestDto;
 import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
 
 public class TestObjectFactory {
     public static Store createStore(Long sellerId, String storeName, String description, String imageUrl) {
         Store store = Store.of(sellerId, storeName);
 
-        StoreDto storeDto = StoreDto.of(storeName, description, imageUrl);
-        store.update(storeDto);
+        StoreRequestDto storeRequestDto = new StoreRequestDto(storeName, description, imageUrl);
+        store.update(storeRequestDto);
 
         return store;
+    }
+
+    public static Product createProduct(Store store, String productName, int price, int inventory) {
+        return Product.builder()
+                .store(store)
+                .name(productName)
+                .price(price)
+                .inventory(inventory)
+                .salesRate(0)
+                .build();
     }
 }


### PR DESCRIPTION
## resolve #95

## 변경사항

### 프로덕션 코드
- Product 엔티티에 store 필드 추가
- Store 엔티티에 products 필드 추가
- 기타 두 도메인을 연결하기 위한 수정

### 테스트 코드
- 상품 목록을 포함한 가게 조회에 대한 테스트 코드 추가

## 기타
- 상품 도메인 코드의 변경을 최소화하면서 매핑하는 방향으로 진행

## 배포
- [x] 확인