### PR TITLE
[#124] 상수명 변경 등 리팩토링

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/user/controller/AuthenticationController.java
+++ b/src/main/java/com/firstone/greenjangteo/user/controller/AuthenticationController.java
@@ -90,7 +90,7 @@ public class AuthenticationController {
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @PatchMapping("/{userId}/email")
     public ResponseEntity<Void> updateEmail
-            (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = ID_EXAMPLE) String userId,
+            (@PathVariable("userId") @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId,
              @RequestBody @ApiParam(value = UPDATE_UPDATE_EMAIL_FORM) EmailRequestDto emailRequestDto) {
         InputFormatValidator.validateId(userId);
         authenticationService.updateEmail(Long.parseLong(userId), emailRequestDto);
@@ -102,7 +102,7 @@ public class AuthenticationController {
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @PatchMapping("/{userId}/phone")
     public ResponseEntity<Void> updatePhone
-            (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = ID_EXAMPLE) String userId,
+            (@PathVariable("userId") @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId,
              @RequestBody @ApiParam(value = UPDATE_PHONE_FORM) PhoneRequestDto phoneRequestDto) {
         InputFormatValidator.validateId(userId);
         authenticationService.updatePhone(Long.parseLong(userId), phoneRequestDto);
@@ -114,7 +114,7 @@ public class AuthenticationController {
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @PatchMapping("/{userId}/password")
     public ResponseEntity<Void> updatePassword
-            (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = ID_EXAMPLE) String userId,
+            (@PathVariable("userId") @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId,
              @RequestBody @ApiParam(value = UPDATE_PASSWORD_FORM)
              PasswordUpdateRequestDto passwordUpdateRequestDto) {
         InputFormatValidator.validateId(userId);
@@ -127,7 +127,7 @@ public class AuthenticationController {
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @DeleteMapping("/{userId}")
     public ResponseEntity<Void> deleteUser(
-            @PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = ID_EXAMPLE) String userId,
+            @PathVariable("userId") @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId,
             @RequestBody @ApiParam(value = DELETE_USER_FORM) DeleteRequestDto deleteRequestDto) {
         InputFormatValidator.validateId(userId);
         authenticationService.deleteUser(Long.parseLong(userId), deleteRequestDto);

--- a/src/main/java/com/firstone/greenjangteo/user/controller/UserController.java
+++ b/src/main/java/com/firstone/greenjangteo/user/controller/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @GetMapping("/{userId}/profile")
     public ResponseEntity<UserResponseDto> getUserDetails
-            (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = ID_EXAMPLE) String userId) {
+            (@PathVariable("userId") @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId) {
         InputFormatValidator.validateId(userId);
         User user = userService.getUser(Long.parseLong(userId));
 
@@ -49,7 +49,7 @@ public class UserController {
     @ApiOperation(value = GET_USER, notes = GET_USER_DESCRIPTION)
     @GetMapping("/{userId}")
     public ResponseEntity<UserResponseDto> getUser
-            (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = ID_EXAMPLE) String userId) {
+            (@PathVariable("userId") @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId) {
         InputFormatValidator.validateId(userId);
         User user = userService.getUser(Long.parseLong(userId));
 
@@ -60,7 +60,7 @@ public class UserController {
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @PatchMapping("/{userId}/address")
     public ResponseEntity<Void> updateAddress
-            (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = ID_EXAMPLE) String userId,
+            (@PathVariable("userId") @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId,
              @RequestBody @ApiParam(value = UPDATE_ADDRESS_FORM) AddressDto addressDto) {
         InputFormatValidator.validateId(userId);
         userService.updateAddress(Long.parseLong(userId), addressDto);

--- a/src/main/java/com/firstone/greenjangteo/user/domain/store/controller/StoreController.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/store/controller/StoreController.java
@@ -32,7 +32,7 @@ public class StoreController {
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @GetMapping("/{userId}")
     public ResponseEntity<StoreResponseDto> getStore
-            (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = ID_EXAMPLE) String userId) {
+            (@PathVariable("userId") @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId) {
         InputFormatValidator.validateId(userId);
         Store store = storeService.getStore(Long.parseLong(userId));
 
@@ -43,7 +43,7 @@ public class StoreController {
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @PutMapping("/{userId}")
     public ResponseEntity<Void> updateStore
-            (@PathVariable("userId") @ApiParam(value = USER_ID_FORM, example = ID_EXAMPLE) String userId,
+            (@PathVariable("userId") @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId,
              @RequestBody @ApiParam(value = UPDATE_STORE_FORM) StoreRequestDto storeRequestDto) {
         InputFormatValidator.validateId(userId);
         storeService.updateStore(Long.parseLong(userId), storeRequestDto);

--- a/src/main/java/com/firstone/greenjangteo/user/dto/request/UserIdRequestDto.java
+++ b/src/main/java/com/firstone/greenjangteo/user/dto/request/UserIdRequestDto.java
@@ -1,13 +1,18 @@
 package com.firstone.greenjangteo.user.dto.request;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
+import static com.firstone.greenjangteo.web.ApiConstant.USER_ID_VALUE;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
 public class UserIdRequestDto {
+    @ApiModelProperty(value = USER_ID_VALUE, example = ID_EXAMPLE)
     private String userId;
 }

--- a/src/main/java/com/firstone/greenjangteo/web/ApiConstant.java
+++ b/src/main/java/com/firstone/greenjangteo/web/ApiConstant.java
@@ -1,7 +1,7 @@
 package com.firstone.greenjangteo.web;
 
 public class ApiConstant {
-    public static final String USER_ID_FORM = "회원 ID";
+    public static final String USER_ID_VALUE = "회원 ID";
 
     public static final String EMAIL_EXAMPLE = "abcd@abc.com";
     public static final String PASSWORD_VALUE = "비밀번호";

--- a/src/test/java/com/firstone/greenjangteo/user/model/entity/UserTest.java
+++ b/src/test/java/com/firstone/greenjangteo/user/model/entity/UserTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -21,6 +22,7 @@ import static com.firstone.greenjangteo.user.model.Role.ROLE_BUYER;
 import static com.firstone.greenjangteo.user.testutil.UserTestConstant.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class UserTest {
     @Autowired

--- a/src/test/java/com/firstone/greenjangteo/user/model/security/PasswordTest.java
+++ b/src/test/java/com/firstone/greenjangteo/user/model/security/PasswordTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 
 import static com.firstone.greenjangteo.user.excpeption.message.BlankExceptionMessage.PASSWORD_NO_VALUE_EXCEPTION;
 import static com.firstone.greenjangteo.user.excpeption.message.InvalidExceptionMessage.INVALID_PASSWORD_EXCEPTION;
@@ -15,6 +16,7 @@ import static com.firstone.greenjangteo.user.testutil.UserTestConstant.PASSWORD2
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class PasswordTest {
     @Autowired


### PR DESCRIPTION
## resolve #124

## 변경사항
- USER_ID_FORM의 상수명을 USER_ID_VALUE로 변경
- UserTest와 PasswordTest를 H2 데이터베이스에서 진행하도록 변경
- UserIdRequestDto에 Swagger 안내 문구 추가