### PR TITLE
[#127] 주문 도메인 리팩토링

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/order/model/OrderProducts.java
+++ b/src/main/java/com/firstone/greenjangteo/order/model/OrderProducts.java
@@ -24,7 +24,7 @@ public class OrderProducts {
     @OneToMany(mappedBy = "order", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.LAZY)
     private List<OrderProduct> orderProducts;
 
-    private OrderProducts(List<OrderProduct> orderProducts) {
+    OrderProducts(List<OrderProduct> orderProducts) {
         this.orderProducts = orderProducts;
     }
 

--- a/src/main/java/com/firstone/greenjangteo/order/model/entity/Order.java
+++ b/src/main/java/com/firstone/greenjangteo/order/model/entity/Order.java
@@ -67,7 +67,7 @@ public class Order extends BaseEntity {
         OrderProducts orderProducts
                 = OrderProducts.from(orderRequestDto.getOrderProductRequestDtos(), productService, store.getSellerId());
 
-        return Order.builder()
+        Order order = Order.builder()
                 .store(store)
                 .buyer(buyer)
                 .orderProducts(orderProducts)
@@ -75,6 +75,10 @@ public class Order extends BaseEntity {
                 .totalOrderPrice(TotalOrderPrice.from(orderProducts))
                 .shippingAddress(Address.from(orderRequestDto.getShippingAddressDto()))
                 .build();
+
+        orderProducts.addOrder(order);
+
+        return order;
     }
 
     @Override
@@ -83,13 +87,13 @@ public class Order extends BaseEntity {
         if (o == null || getClass() != o.getClass()) return false;
         Order order = (Order) o;
         return Objects.equals(id, order.id) && Objects.equals(store, order.store)
-                && Objects.equals(buyer, order.buyer) && Objects.equals(orderProducts, order.orderProducts)
-                && orderStatus == order.orderStatus && Objects.equals(totalOrderPrice, order.totalOrderPrice)
+                && Objects.equals(buyer, order.buyer) && orderStatus == order.orderStatus
+                && Objects.equals(totalOrderPrice, order.totalOrderPrice)
                 && Objects.equals(shippingAddress, order.shippingAddress);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, store, buyer, orderProducts, orderStatus, totalOrderPrice, shippingAddress);
+        return Objects.hash(id, store, buyer, orderStatus, totalOrderPrice, shippingAddress);
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/order/service/OrderServiceImpl.java
@@ -38,7 +38,6 @@ public class OrderServiceImpl implements OrderService {
         Store store = storeService.getStore(Long.parseLong(orderRequestDto.getSellerId()));
         User buyer = userService.getUser(Long.parseLong(orderRequestDto.getBuyerId()));
         Order order = Order.from(store, buyer, orderRequestDto, productService);
-        order.getOrderProducts().addOrder(order);
 
         return orderRepository.save(order);
     }
@@ -61,7 +60,6 @@ public class OrderServiceImpl implements OrderService {
         );
 
         Order order = Order.from(store, buyer, orderRequestDto, productService);
-        order.getOrderProducts().addOrder(order);
 
         return orderRepository.save(order);
     }

--- a/src/main/java/com/firstone/greenjangteo/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/order/service/OrderServiceImpl.java
@@ -16,6 +16,7 @@ import com.firstone.greenjangteo.user.model.entity.User;
 import com.firstone.greenjangteo.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.ArrayList;
@@ -23,9 +24,12 @@ import java.util.List;
 
 import static com.firstone.greenjangteo.order.excpeption.message.NotFoundExceptionMessage.ORDERED_USER_ID_NOT_FOUND_EXCEPTION;
 import static com.firstone.greenjangteo.order.excpeption.message.NotFoundExceptionMessage.ORDER_ID_NOT_FOUND_EXCEPTION;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+import static org.springframework.transaction.annotation.Isolation.SERIALIZABLE;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, timeout = 10)
 public class OrderServiceImpl implements OrderService {
     private final StoreService storeService;
     private final UserService userService;
@@ -34,6 +38,7 @@ public class OrderServiceImpl implements OrderService {
     private final OrderRepository orderRepository;
 
     @Override
+    @Transactional(isolation = SERIALIZABLE, timeout = 20)
     public Order createOrder(OrderRequestDto orderRequestDto) {
         Store store = storeService.getStore(Long.parseLong(orderRequestDto.getSellerId()));
         User buyer = userService.getUser(Long.parseLong(orderRequestDto.getBuyerId()));
@@ -43,6 +48,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
+    @Transactional(isolation = SERIALIZABLE, timeout = 20)
     public Order createOrderFromCart(CartOrderRequestDto cartOrderRequestDto) {
         Long buyerId = Long.parseLong(cartOrderRequestDto.getBuyerId());
         User buyer = userService.getUser(buyerId);
@@ -65,6 +71,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
+    @Transactional(isolation = SERIALIZABLE, readOnly = true, timeout = 20)
     public List<Order> getOrders(UserIdRequestDto userIdRequestDto) {
         User user = userService.getUser(Long.parseLong(userIdRequestDto.getUserId()));
 
@@ -76,6 +83,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
     public Order getOrder(Long orderId) {
         return orderRepository.findById(orderId)
                 .orElseThrow(() -> new EntityNotFoundException(ORDER_ID_NOT_FOUND_EXCEPTION + orderId));

--- a/src/test/java/com/firstone/greenjangteo/order/model/OrderProductsTest.java
+++ b/src/test/java/com/firstone/greenjangteo/order/model/OrderProductsTest.java
@@ -84,8 +84,10 @@ class OrderProductsTest {
         );
 
         // when
-        OrderProducts orderProducts1 = OrderProducts.from(orderProductRequestDtos1, productService, store.getSellerId());
-        OrderProducts orderProducts2 = OrderProducts.from(orderProductRequestDtos2, productService, store.getSellerId());
+        OrderProducts orderProducts1
+                = OrderProducts.from(orderProductRequestDtos1, productService, store.getSellerId());
+        OrderProducts orderProducts2
+                = OrderProducts.from(orderProductRequestDtos2, productService, store.getSellerId());
 
         // then
         assertThat(orderProducts1).isEqualTo(orderProducts2);

--- a/src/test/java/com/firstone/greenjangteo/order/model/TotalOrderPriceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/order/model/TotalOrderPriceTest.java
@@ -1,5 +1,60 @@
 package com.firstone.greenjangteo.order.model;
 
-class TotalOrderPriceTest {
+import com.firstone.greenjangteo.order.model.entity.OrderProduct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static com.firstone.greenjangteo.order.testutil.OrderTestConstant.QUANTITY1;
+import static com.firstone.greenjangteo.order.testutil.OrderTestConstant.QUANTITY2;
+import static com.firstone.greenjangteo.user.domain.store.testutil.StoreTestConstant.PRICE1;
+import static com.firstone.greenjangteo.user.domain.store.testutil.StoreTestConstant.PRICE2;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TotalOrderPriceTest {
+    @DisplayName("총 가격이 동일한 주문 상품 목록을 전송하면 동등한 TotalOrderPrice 인스턴스를 생성한다.")
+    @Test
+    void fromSameValue() {
+        // given
+        OrderProduct orderProduct = mock(OrderProduct.class);
+        OrderProducts orderProducts = new OrderProducts(List.of(orderProduct, orderProduct));
+
+        OrderPrice orderPrice = OrderPrice.from(PRICE1, Quantity.of(QUANTITY1));
+
+        when(orderProduct.getOrderPrice()).thenReturn(orderPrice);
+
+        // when
+        TotalOrderPrice totalOrderPrice1 = TotalOrderPrice.from(orderProducts);
+        TotalOrderPrice totalOrderPrice2 = TotalOrderPrice.from(orderProducts);
+
+        // then
+        assertThat(totalOrderPrice1).isEqualTo(totalOrderPrice2);
+        assertThat(totalOrderPrice1.hashCode()).isEqualTo(totalOrderPrice2.hashCode());
+    }
+
+    @DisplayName("총 가격이 다른 주문 상품 목록을 전송하면 동등하지 않은 TotalOrderPrice 인스턴스를 생성한다.")
+    @Test
+    void fromDifferentValue() {
+        // given
+        OrderProduct orderProduct = mock(OrderProduct.class);
+        OrderProducts orderProducts = new OrderProducts(List.of(orderProduct, orderProduct));
+
+        OrderPrice orderPrice1 = OrderPrice.from(PRICE1, Quantity.of(QUANTITY1));
+        OrderPrice orderPrice2 = OrderPrice.from(PRICE2, Quantity.of(QUANTITY2));
+
+        when(orderProduct.getOrderPrice()).thenReturn(orderPrice1);
+
+        // when
+        TotalOrderPrice totalOrderPrice1 = TotalOrderPrice.from(orderProducts);
+
+        when(orderProduct.getOrderPrice()).thenReturn(orderPrice2);
+        TotalOrderPrice totalOrderPrice2 = TotalOrderPrice.from(orderProducts);
+
+        // then
+        assertThat(totalOrderPrice1).isNotEqualTo(totalOrderPrice2);
+        assertThat(totalOrderPrice1.hashCode()).isNotEqualTo(totalOrderPrice2.hashCode());
+    }
 }


### PR DESCRIPTION
## resolve #127

## 변경사항

- 주문 도메인의 addOrder 메서드를 Order 클래스의 from 메서드 내부로  이동
    - OrderServiceImpl 클래스의 createOrder 메서드에서 삭제
    - OrderServiceImpl 클래스의 createOrderFromCart 메서드에서 삭제
- 주문 도메인 테스트 코드 수정
    - TotalOrderPrice 클래스의 동등성 테스트 코드 추가
    - OrderProductsTest 클래스의 일부 라인 개행
- 비즈니스 로직을 수행하는 메서드에 트랜잭션 적용