### PR TITLE
[#140] 로그인 요청의 응답값과 가게 삭제 시 데이터 삭제 로직 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/user/controller/AuthenticationController.java
+++ b/src/main/java/com/firstone/greenjangteo/user/controller/AuthenticationController.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
-import java.time.LocalDateTime;
 
 import static com.firstone.greenjangteo.web.ApiConstant.*;
 
@@ -78,12 +77,9 @@ public class AuthenticationController {
     public ResponseEntity<SignInResponseDto> signInUser
             (@RequestBody @ApiParam(value = SIGN_IN_FORM) SignInForm signInForm) {
         User user = authenticationService.signInUser(signInForm);
-
-        Long userId = user.getId();
-        LocalDateTime loggedInTime = user.getLastLoggedInAt();
         String token = jwtTokenProvider.generateToken(String.valueOf(user.getId()), user.getRoles().toStrings());
 
-        return ResponseEntity.status(HttpStatus.OK).body(new SignInResponseDto(userId, loggedInTime, token));
+        return ResponseEntity.status(HttpStatus.OK).body(SignInResponseDto.from(user, token));
     }
 
     @ApiOperation(value = UPDATE_EMAIL, notes = UPDATE_UPDATE_EMAIL_DESCRIPTION)

--- a/src/main/java/com/firstone/greenjangteo/user/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/store/service/StoreServiceImpl.java
@@ -1,5 +1,7 @@
 package com.firstone.greenjangteo.user.domain.store.service;
 
+import com.firstone.greenjangteo.product.domain.model.Product;
+import com.firstone.greenjangteo.product.repository.CategoryRepository;
 import com.firstone.greenjangteo.user.domain.store.dto.StoreRequestDto;
 import com.firstone.greenjangteo.user.domain.store.exception.general.DuplicateStoreNameException;
 import com.firstone.greenjangteo.user.domain.store.model.StoreName;
@@ -20,6 +22,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED, timeout = 10)
 public class StoreServiceImpl implements StoreService {
     private final StoreRepository storeRepository;
+    private final CategoryRepository categoryRepository;
 
     @Override
     public void createStore(Long userId, String storeName) {
@@ -45,6 +48,7 @@ public class StoreServiceImpl implements StoreService {
     @Override
     public void deleteStore(long id) {
         if (storeRepository.existsById(id)) {
+            deleteCategories(id);
             storeRepository.deleteById(id);
             return;
         }
@@ -56,5 +60,11 @@ public class StoreServiceImpl implements StoreService {
         if (storeRepository.existsByStoreName(StoreName.of(storeName))) {
             throw new DuplicateStoreNameException(DUPLICATE_STORE_NAME_EXCEPTION + storeName);
         }
+    }
+
+    private void deleteCategories(long id) {
+        getStore(id).getProducts().stream()
+                .map(Product::getId)
+                .forEach(categoryRepository::deleteAllByProductId);
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/user/dto/response/SignInResponseDto.java
+++ b/src/main/java/com/firstone/greenjangteo/user/dto/response/SignInResponseDto.java
@@ -4,19 +4,34 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.firstone.greenjangteo.user.model.entity.User;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @AllArgsConstructor
+@Builder
 @Getter
 public class SignInResponseDto {
     private final Long userId;
+
+    private final List<String> roleDescriptions;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private final LocalDateTime loggedInAt;
 
     private final String token;
+
+    public static SignInResponseDto from(User user, String token) {
+        return SignInResponseDto.builder()
+                .userId(user.getId())
+                .roleDescriptions(user.getRoles().toDescriptions())
+                .loggedInAt(user.getLastLoggedInAt())
+                .token(token)
+                .build();
+    }
 }

--- a/src/main/java/com/firstone/greenjangteo/user/model/Role.java
+++ b/src/main/java/com/firstone/greenjangteo/user/model/Role.java
@@ -1,8 +1,10 @@
 package com.firstone.greenjangteo.user.model;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum Role {
     ROLE_ADMIN("관리자"),
     ROLE_SELLER("판매자"),

--- a/src/main/java/com/firstone/greenjangteo/user/model/embedment/Roles.java
+++ b/src/main/java/com/firstone/greenjangteo/user/model/embedment/Roles.java
@@ -42,6 +42,10 @@ public class Roles {
         return roles.stream().map(Role::toString).collect(Collectors.toList());
     }
 
+    public List<String> toDescriptions() {
+        return roles.stream().map(Role::getDescription).collect(Collectors.toList());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;


### PR DESCRIPTION
## resolve #140


## 추가사항
- 로그인 요청 응답값에 회원의 권한 정보 추가
- 가게 삭제 시 가게의 상품과 연결된 카테고리 튜플 삭제 로직 추가