### PR TITLE
[#162] 유효기간 만료 시 쿠폰 일괄 삭제 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/application/job/DeleteExpiredCouponJobConfig.java
+++ b/src/main/java/com/firstone/greenjangteo/application/job/DeleteExpiredCouponJobConfig.java
@@ -1,0 +1,140 @@
+package com.firstone.greenjangteo.application.job;
+
+import com.firstone.greenjangteo.coupon.model.entity.Coupon;
+import com.firstone.greenjangteo.coupon.model.entity.CouponGroup;
+import com.firstone.greenjangteo.coupon.repository.CouponGroupRepository;
+import com.firstone.greenjangteo.coupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static com.firstone.greenjangteo.application.job.utility.LogConstant.UPDATING_COUPON;
+
+@Configuration
+@RequiredArgsConstructor
+public class DeleteExpiredCouponJobConfig {
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final CouponGroupRepository couponGroupRepository;
+    private final CouponRepository couponRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final Logger log = LoggerFactory.getLogger(DeleteExpiredCouponJobConfig.class);
+
+    private static final String JOB_NAME = "deleteExpiredCouponsJob";
+    private static final String STEP_NAME = "deleteExpiredCouponsStep";
+    private static final String COUPON_DELETE_QUERY = "DELETE FROM coupon WHERE id = ?";
+
+    @Bean
+    public Job deleteExpiredCouponJob() {
+        return jobBuilderFactory
+                .get(JOB_NAME)
+                .start(deleteExpiredCouponStep())
+                .build();
+    }
+
+    @Bean
+    public Step deleteExpiredCouponStep() {
+        return stepBuilderFactory
+                .get(STEP_NAME)
+                .<Coupon, Coupon>chunk(1_000) // 긴급성이 낮은 작업이므로 Coupon 단위 1,000으로 설정
+                .reader(expiredCouponReader())
+                .writer(expiredCouponWriter())
+                .faultTolerant()
+                .retryLimit(10)
+                .retry(Exception.class)
+                .build();
+    }
+
+    public ItemReader<Coupon> expiredCouponReader() {
+        return new ExpiredCouponReader(couponRepository);
+    }
+
+    public class ExpiredCouponReader implements ItemReader<Coupon> {
+        private final CouponRepository couponRepository;
+        private Iterator<Coupon> couponIterator;
+
+        public ExpiredCouponReader(CouponRepository couponRepository) {
+            this.couponRepository = couponRepository;
+        }
+
+        @Override
+        public Coupon read() {
+            if (couponIterator == null) {
+                LocalDateTime endOfToday = LocalDate.now().atTime(LocalTime.MAX);
+                List<Coupon> expiredCoupons = couponRepository.findByExpiredAtBefore(endOfToday);
+                couponIterator = expiredCoupons.iterator();
+            }
+
+            if (couponIterator.hasNext()) {
+                return couponIterator.next();
+            }
+
+            return null;
+        }
+    }
+
+    @Bean
+    public ItemWriter<Coupon> expiredCouponWriter() {
+        return coupons -> {
+            jdbcTemplate.batchUpdate(
+                    COUPON_DELETE_QUERY,
+                    new BatchPreparedStatementSetter() {
+                        @Override
+                        public void setValues(PreparedStatement ps, int i) throws SQLException {
+                            Long couponId = coupons.get(i).getId();
+
+                            log.info(UPDATING_COUPON, couponId);
+                            ps.setLong(1, couponId);
+                        }
+
+                        @Override
+                        public int getBatchSize() {
+                            return coupons.size();
+                        }
+                    }
+            );
+
+            Map<Long, Integer> unassignedCouponCountByGroup = new HashMap<>();
+            for (Coupon coupon : coupons) {
+                classifyCouponUserUnassigned(coupon, unassignedCouponCountByGroup);
+            }
+
+            unassignedCouponCountByGroup.forEach((couponGroupId, count) -> {
+                CouponGroup couponGroup = couponGroupRepository.findById(couponGroupId).orElse(null);
+                if (couponGroup != null) {
+                    couponGroup.reduceRemainingQuantity(count);
+                    couponGroupRepository.save(couponGroup);
+                }
+            });
+        };
+    }
+
+    private void classifyCouponUserUnassigned(Coupon coupon, Map<Long, Integer> unassignedCouponCountByGroup) {
+        Long couponGroupId = coupon.getCouponGroup().getId();
+
+        if (coupon.getUser() == null) {
+            unassignedCouponCountByGroup.merge(couponGroupId, 1, Integer::sum);
+        }
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/application/scheduler/JobScheduler.java
+++ b/src/main/java/com/firstone/greenjangteo/application/scheduler/JobScheduler.java
@@ -29,6 +29,10 @@ public class JobScheduler {
     private static final String CRON_MIDNIGHT_EXPRESSION = "0 0 0 * * *";
     private static final String SCHEDULED_ISSUE_JOB_START = "Beginning to scheduled issuing coupon job";
 
+    private static final String CRON_SIX_O_CLOCK_EXPRESSION = "0 0 6 * * *";
+    private static final String SCHEDULED_DELETE_EXPIRED_JOB_START
+            = "Beginning to scheduled deleting expired coupon job";
+
     private int userSize;
     private boolean isIssueToAllUsersRequired;
 
@@ -62,6 +66,12 @@ public class JobScheduler {
         }
 
         isIssueToAllUsersRequired = false;
+    }
+
+    @Scheduled(cron = CRON_SIX_O_CLOCK_EXPRESSION)
+    public void runDeleteExpiredCouponJob() throws JobExecutionException {
+        log.info(SCHEDULED_DELETE_EXPIRED_JOB_START);
+        couponService.deleteExpiredCoupons();
     }
 
     private void createRequiredCoupons(CouponGroup couponGroup) throws JobExecutionException {

--- a/src/main/java/com/firstone/greenjangteo/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/repository/CouponRepository.java
@@ -5,10 +5,13 @@ import com.firstone.greenjangteo.coupon.model.entity.CouponGroup;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
     List<Coupon> findByCouponGroupAndUserIsNull(CouponGroup couponGroup, Pageable pageable);
 
     List<Coupon> findAllByUserId(Long userId);
+
+    List<Coupon> findByExpiredAtBefore(LocalDateTime localDateTime);
 }

--- a/src/main/java/com/firstone/greenjangteo/coupon/service/CouponService.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/service/CouponService.java
@@ -11,10 +11,12 @@ public interface CouponService {
 
     void issueCoupons() throws JobExecutionException;
 
+    void provideCouponsToUsers(ProvideCouponsToUsersRequestDto provideCouponsToUsersRequestDto)
+            throws JobExecutionException;
+
+    void deleteExpiredCoupons() throws JobExecutionException;
+
     void provideCouponsToUser(ProvideCouponsToUserRequestDto provideCouponsToUserRequestDto);
 
     CouponGroup getCouponGroup(String couponName);
-
-    void provideCouponsToUsers(ProvideCouponsToUsersRequestDto provideCouponsToUsersRequestDto)
-            throws JobExecutionException;
 }

--- a/src/test/java/com/firstone/greenjangteo/application/job/DeleteExpiredCouponJobConfigTest.java
+++ b/src/test/java/com/firstone/greenjangteo/application/job/DeleteExpiredCouponJobConfigTest.java
@@ -1,0 +1,52 @@
+package com.firstone.greenjangteo.application.job;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class DeleteExpiredCouponJobConfigTest {
+    @Autowired
+    private DeleteExpiredCouponJobConfig deleteExpiredCouponJobConfig;
+
+    @MockBean
+    private JobLauncher jobLauncher;
+
+    @MockBean(name = "issueCouponJob")
+    private Job deleteExpiredCouponJob;
+
+    @DisplayName("만료된 쿠폰 삭제를 위해 deleteExpiredCouponJob을 실행한다.")
+    @Test
+    void run() throws Exception {
+        // given, when
+        jobLauncher.run(deleteExpiredCouponJob, new JobParameters());
+
+        // then
+        verify(jobLauncher, times(1)).run(eq(deleteExpiredCouponJob), any(JobParameters.class));
+    }
+
+    @DisplayName("JobParameters를 전송해 deleteExpiredCouponJob을 실행한다.")
+    @Test
+    void runWithParameters() throws Exception {
+        // given
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+
+        // when, then
+        jobLauncher.run(deleteExpiredCouponJob, jobParameters);
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/coupon/service/CouponServiceTest.java
@@ -204,6 +204,35 @@ class CouponServiceTest {
                 .isNotNull();
     }
 
+    @DisplayName("유효기간이 오늘 이전인 대량의 쿠폰을 삭제할 수 있다.")
+    @Test
+    void deleteExpiredCoupons() throws JobExecutionException {
+        // given
+        CouponGroup couponGroup1
+                = CouponTestObjectFactory.createCouponGroup(
+                COUPON_NAME1, AMOUNT, DESCRIPTION, ISSUE_QUANTITY1, tomorrow, EXPIRATION_PERIOD1
+        );
+        CouponGroup couponGroup2
+                = CouponTestObjectFactory.createCouponGroup(
+                COUPON_NAME2, AMOUNT, DESCRIPTION, ISSUE_QUANTITY2, tomorrow, EXPIRATION_PERIOD2
+        );
+
+        List<Coupon> coupons1 = CouponTestObjectFactory.createAndIssueCoupons(couponGroup1, LocalDateTime.now());
+        List<Coupon> coupons2
+                = CouponTestObjectFactory.createAndIssueCoupons(couponGroup2, LocalDateTime.now().plusDays(1));
+
+        couponGroupRepository.saveAll(List.of(couponGroup1, couponGroup2));
+        couponRepository.saveAll(coupons1);
+        couponRepository.saveAll(coupons2);
+
+        // when
+        couponService.deleteExpiredCoupons();
+        List<Coupon> foundCoupons = couponRepository.findAll();
+
+        // then
+        assertThat(foundCoupons).hasSize(coupons2.size());
+    }
+
     @DisplayName("쿠폰 이름을 통해 쿠폰 그룹을 찾을 수 있다.")
     @Test
     @Transactional

--- a/src/test/java/com/firstone/greenjangteo/coupon/testutil/CouponTestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/coupon/testutil/CouponTestObjectFactory.java
@@ -64,4 +64,14 @@ public class CouponTestObjectFactory {
 
         return coupons;
     }
+
+    public static List<Coupon> createAndIssueCoupons(CouponGroup couponGroup, LocalDateTime expirationTime) {
+        List<Coupon> coupons = createCoupons(couponGroup);
+
+        for (Coupon coupon : coupons) {
+            coupon.issueCoupon(LocalDateTime.now(), expirationTime);
+        }
+
+        return coupons;
+    }
 }


### PR DESCRIPTION
## resolve #162

## 추가사항

### 프로덕션 코드
- 매일 오전 6시에 실행되도록 스케줄러 설정
- JobScheduler 클래스에서 CouponService 인터페이스의 deleteExpiredCoupons 메서드 호출
- CouponServiceImpl 클래스의 removeCoupons 메서드에서 deleteExpiredCouponJob을 통한 쿠폰 일괄 삭제 로직 수행
- 유효기간 만료일 기반의 쿠폰 데이터 검색
- 유효기간 만료일이 deleteExpiredCouponJob 실행 날짜와 일치하는 쿠폰들에 대한 쿠폰 삭제 작업 수행

### 테스트 코드
- deleteExpiredCouponJob 실행
- JobParameters를 통한 deleteExpiredCouponJob 실행
- CouponServiceImpl 클래스의 deleteExpiredCoupons 메서드 로직 수행
- 유효기간 만료일 기반의 쿠폰 데이터 검색
- 쿠폰 일괄 삭제 작업 수행