### PR TITLE
[#203] Redis Cache 적용 시 발생하는 직렬화, 역직렬화 문제 해결

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/hibernate/HibernateCollectionIdResolver.java
+++ b/src/main/java/com/firstone/greenjangteo/hibernate/HibernateCollectionIdResolver.java
@@ -1,0 +1,56 @@
+package com.firstone.greenjangteo.hibernate;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import org.hibernate.collection.internal.*;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.*;
+
+public class HibernateCollectionIdResolver extends TypeIdResolverBase {
+    public HibernateCollectionIdResolver() {
+    }
+
+    @Override
+    public String idFromValue(Object value) {
+        if (value instanceof PersistentArrayHolder) {
+            return Array.class.getName();
+        } else if (value instanceof PersistentBag || value instanceof PersistentIdentifierBag
+                || value instanceof PersistentList) {
+            return List.class.getName();
+        } else if (value instanceof PersistentSortedMap) {
+            return TreeMap.class.getName();
+        } else if (value instanceof PersistentSortedSet) {
+            return TreeSet.class.getName();
+        } else if (value instanceof PersistentMap) {
+            return HashMap.class.getName();
+        } else if (value instanceof PersistentSet) {
+            return HashSet.class.getName();
+        } else {
+            //default is JDK collection
+            return value.getClass().getName();
+        }
+    }
+
+    @Override
+    public String idFromValueAndType(Object value, Class<?> suggestedType) {
+        return idFromValue(value);
+    }
+
+    @Override
+    public JavaType typeFromId(DatabindContext ctx, String id) throws IOException {
+        try {
+            return ctx.getConfig().constructType(Class.forName(id));
+        } catch (ClassNotFoundException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism() {
+        return JsonTypeInfo.Id.CLASS;
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/hibernate/HibernateCollectionMixIn.java
+++ b/src/main/java/com/firstone/greenjangteo/hibernate/HibernateCollectionMixIn.java
@@ -1,0 +1,9 @@
+package com.firstone.greenjangteo.hibernate;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonTypeIdResolver(value = HibernateCollectionIdResolver.class)
+public class HibernateCollectionMixIn {
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/image/model/entity/Image.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/image/model/entity/Image.java
@@ -1,5 +1,6 @@
 package com.firstone.greenjangteo.post.domain.image.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.firstone.greenjangteo.audit.BaseEntity;
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.model.entity.Post;
@@ -22,11 +23,12 @@ public class Image extends BaseEntity {
     @Column(nullable = false)
     private String url;
 
-    @Column(name = "position", unique = true)
+    @Column(name = "position")
     private int positionInContent;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
+    @JsonBackReference
     private Post post;
 
     @Builder

--- a/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
+++ b/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
@@ -1,5 +1,6 @@
 package com.firstone.greenjangteo.post.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.firstone.greenjangteo.audit.BaseEntity;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
 import com.firstone.greenjangteo.post.dto.PostRequestDto;
@@ -36,6 +37,7 @@ public class Post extends BaseEntity {
     private int view;
 
     @OneToMany(mappedBy = "post", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.LAZY)
+    @JsonManagedReference
     private List<Image> images;
 
     @Builder

--- a/src/main/java/com/firstone/greenjangteo/user/model/Username.java
+++ b/src/main/java/com/firstone/greenjangteo/user/model/Username.java
@@ -1,5 +1,8 @@
 package com.firstone.greenjangteo.user.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 import java.util.Objects;
@@ -15,7 +18,8 @@ public class Username {
         this.username = username;
     }
 
-    public static Username of(String username) {
+    @JsonCreator
+    public static Username of(@JsonProperty("username") String username) {
         validate(username);
 
         return new Username(username);
@@ -34,6 +38,7 @@ public class Username {
         return Objects.hash(username);
     }
 
+    @JsonProperty(value = "username")
     public String getValue() {
         return username;
     }

--- a/src/main/java/com/firstone/greenjangteo/user/model/entity/User.java
+++ b/src/main/java/com/firstone/greenjangteo/user/model/entity/User.java
@@ -1,5 +1,10 @@
 package com.firstone.greenjangteo.user.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.firstone.greenjangteo.audit.BaseEntity;
 import com.firstone.greenjangteo.coupon.model.entity.Coupon;
 import com.firstone.greenjangteo.user.dto.AddressDto;
@@ -35,6 +40,7 @@ public class User extends BaseEntity {
 
     @Convert(converter = Email.EmailConverter.class)
     @Column(nullable = false, unique = true, length = 30)
+    @JsonIgnore
     private Email email;
 
     @Convert(converter = Username.UsernameConverter.class)
@@ -43,14 +49,17 @@ public class User extends BaseEntity {
 
     @Convert(converter = Password.PasswordConverter.class)
     @Column(nullable = false)
+    @JsonIgnore
     private Password password;
 
     @Convert(converter = FullName.FullNameConverter.class)
     @Column(nullable = false, length = 5)
+    @JsonIgnore
     private FullName fullName;
 
     @Convert(converter = Phone.PhoneConverter.class)
     @Column(unique = true, length = 11)
+    @JsonIgnore
     private Phone phone;
 
     @Embedded
@@ -60,6 +69,8 @@ public class User extends BaseEntity {
     private Roles roles;
 
     @Column
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime lastLoggedInAt;
 
     @OneToMany(mappedBy = "user", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.LAZY)


### PR DESCRIPTION
## resolve #203

## 변경사항

### User 엔티티
- 게시글에서 사용되지 않는 정보를 담고 있는 포장 객체들을 직렬화 과정에서 제외하기 위해 JsonIgnore 어노테이션 적용
- Username 객체를 역직렬화하기 위해 JsonCreator와 JsonProperty 어노테이션 적용
- lastLoggedInAt 필드에 JsonSerialize와 JsonDeserialize 어노테이션 적용

### Image 엔티티
- Post 엔티티의 images 필드에 JsonManagedReference 어노테이션 적용
- Image 엔티티의 post 필드에 JsonBackReference 어노테이션 적용

### 공통
- HibernateCollectionMixIn 클래스를 통해 HibernateCollectionIdResolver 클래스 등록
- CacheConfig 클래스의 objectMapper 메서드를 통해 HibernateCollectionMixIn 클래스 등록
- redisCacheManage 메서드를 통해 GenericJackson2JsonRedisSerializer에 적용