### PR TITLE
[#207] 게시글 조회 수 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
+++ b/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
@@ -1,5 +1,7 @@
 package com.firstone.greenjangteo.post.controller;
 
+import com.firstone.greenjangteo.post.domain.view.model.entity.View;
+import com.firstone.greenjangteo.post.domain.view.model.service.ViewService;
 import com.firstone.greenjangteo.post.dto.PostRequestDto;
 import com.firstone.greenjangteo.post.dto.PostResponseDto;
 import com.firstone.greenjangteo.post.model.entity.Post;
@@ -25,6 +27,7 @@ import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
 @RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
+    private final ViewService viewService;
 
     private static final String CREATE_POST = "게시물 등록";
     private static final String CREATE_POST_DESCRIPTION = "회원 ID와 게시물 내용을 입력해 게시물을 등록할 수 있습니다.";
@@ -56,8 +59,9 @@ public class PostController {
         InputFormatValidator.validateId(writerId);
 
         Post post = postService.getPost(Long.parseLong(postId), Long.parseLong(writerId));
+        View view = viewService.addAndGetView(post.getId());
 
-        return ResponseEntity.status(HttpStatus.OK).body(PostResponseDto.from(post));
+        return ResponseEntity.status(HttpStatus.OK).body(PostResponseDto.from(post, view.getViewCount()));
     }
 
     private ResponseEntity<PostResponseDto> buildResponse(PostResponseDto postResponseDto) {

--- a/src/main/java/com/firstone/greenjangteo/post/domain/view/model/entity/View.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/view/model/entity/View.java
@@ -1,0 +1,29 @@
+package com.firstone.greenjangteo.post.domain.view.model.entity;
+
+import com.firstone.greenjangteo.audit.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity(name = "view")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "view")
+public class View extends BaseEntity {
+    @Id
+    private Long postId;
+
+    private int viewCount;
+
+    public View(Long postId) {
+        this.postId = postId;
+    }
+
+    public void addViewCount() {
+        ++viewCount;
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewRepository.java
@@ -1,0 +1,7 @@
+package com.firstone.greenjangteo.post.domain.view.model.service;
+
+import com.firstone.greenjangteo.post.domain.view.model.entity.View;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ViewRepository extends JpaRepository<View, Long> {
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewService.java
@@ -1,0 +1,18 @@
+package com.firstone.greenjangteo.post.domain.view.model.service;
+
+import com.firstone.greenjangteo.post.domain.view.model.entity.View;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ViewService {
+    private final ViewRepository viewRepository;
+
+    public View addAndGetView(Long postId) {
+        View view = viewRepository.findById(postId).orElse(new View(postId));
+
+        view.addViewCount();
+        return viewRepository.save(view);
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/post/dto/PostResponseDto.java
+++ b/src/main/java/com/firstone/greenjangteo/post/dto/PostResponseDto.java
@@ -26,7 +26,7 @@ public class PostResponseDto {
     private String username;
     private String subject;
     private String content;
-    private int view;
+    private int viewCount;
     private List<ImageResponseDto> imageResponseDtos;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
@@ -46,6 +46,27 @@ public class PostResponseDto {
                 .username(user.getUsername().getValue())
                 .subject(post.getSubject())
                 .content(post.getContent())
+                .imageResponseDtos(
+                        post.getImages() == null
+                                ? null
+                                : post.getImages().stream().map(ImageResponseDto::from)
+                                .collect(Collectors.toList())
+                )
+                .createdAt(post.getCreatedAt())
+                .modifiedAt(post.getModifiedAt())
+                .build();
+    }
+
+    public static PostResponseDto from(Post post, int viewCount) {
+        User user = post.getUser();
+
+        return PostResponseDto.builder()
+                .postId(post.getId())
+                .userId(user.getId())
+                .username(user.getUsername().getValue())
+                .subject(post.getSubject())
+                .content(post.getContent())
+                .viewCount(viewCount)
                 .imageResponseDtos(
                         post.getImages() == null
                                 ? null

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
@@ -54,7 +54,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    @Transactional(isolation = READ_COMMITTED, timeout = 15)
+    @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 15)
     @Cacheable(key = REQUEST_KEY, condition = GET_KEY_CONDITION, unless = UNLESS_CONDITION, value = KEY_VALUE)
     public Post getPost(Long postId, Long writerId) {
         Post post = postRepository.findByIdAndUserId(postId, writerId)

--- a/src/test/java/com/firstone/greenjangteo/post/controller/PostControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/controller/PostControllerTest.java
@@ -3,6 +3,8 @@ package com.firstone.greenjangteo.post.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
+import com.firstone.greenjangteo.post.domain.view.model.entity.View;
+import com.firstone.greenjangteo.post.domain.view.model.service.ViewService;
 import com.firstone.greenjangteo.post.dto.PostRequestDto;
 import com.firstone.greenjangteo.post.model.entity.Post;
 import com.firstone.greenjangteo.post.service.PostService;
@@ -50,6 +52,9 @@ class PostControllerTest {
     private PostService postService;
 
     @MockBean
+    private ViewService viewService;
+
+    @MockBean
     private JwtTokenProvider jwtTokenProvider;
 
     @MockBean
@@ -86,8 +91,10 @@ class PostControllerTest {
         // given
         User user = mock(User.class);
         Post post = PostTestObjectFactory.createPost(Long.parseLong(POST_ID), SUBJECT, CONTENT, user);
+        View view = mock(View.class);
 
         when(postService.getPost(anyLong(), anyLong())).thenReturn(post);
+        when(viewService.addAndGetView(anyLong())).thenReturn(view);
         when(user.getId()).thenReturn(Long.parseLong(BUYER_ID));
         when(user.getUsername()).thenReturn(Username.of(USERNAME1));
 

--- a/src/test/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewServiceTest.java
@@ -1,0 +1,42 @@
+package com.firstone.greenjangteo.post.domain.view.model.service;
+
+import com.firstone.greenjangteo.post.model.entity.Post;
+import com.firstone.greenjangteo.post.repository.PostRepository;
+import com.firstone.greenjangteo.post.utility.PostTestObjectFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.CONTENT;
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.SUBJECT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ViewServiceTest {
+    @Autowired
+    private ViewService viewService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @DisplayName("조회수를 추가하고 조회할 수 있다.")
+    @Test
+    void addAndGetView() {
+        // given
+        Post post = PostTestObjectFactory.createPost(SUBJECT, CONTENT);
+        postRepository.save(post);
+
+        // when
+        int viewCount1 = viewService.addAndGetView(post.getId()).getViewCount();
+        int viewCount2 = viewService.addAndGetView(post.getId()).getViewCount();
+        int viewCount3 = viewService.addAndGetView(post.getId()).getViewCount();
+
+        // then
+        assertThat(viewCount1).isEqualTo(1);
+        assertThat(viewCount2).isEqualTo(2);
+        assertThat(viewCount3).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
## resolve #207

## 추가사항

### 프로덕션 코드
- View 엔티티
- 게시글 조회 시 조회 수 증가 로직 호출
- 조회 수 증가 비즈니스 로직
- 조회 수 증가 후 반환
- PostServiceImpl 클래스의 getPost 메서드에 readOnly 옵션 추가

### 테스트 코드
- 게시글 조회 시 조회 수 증가 로직 호출,  반환
- 조회 수 증가 비즈니스 로직