### PR TITLE
[#209] 전체 게시글 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/coupon/controller/CouponGroupController.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/controller/CouponGroupController.java
@@ -5,6 +5,7 @@ import com.firstone.greenjangteo.coupon.model.CouponAndGroupEntityToDtoMapper;
 import com.firstone.greenjangteo.coupon.model.entity.Coupon;
 import com.firstone.greenjangteo.coupon.model.entity.CouponGroup;
 import com.firstone.greenjangteo.coupon.service.CouponGroupService;
+import com.firstone.greenjangteo.utility.FormatConverter;
 import com.firstone.greenjangteo.utility.InputFormatValidator;
 import com.firstone.greenjangteo.utility.RoleValidator;
 import io.swagger.annotations.ApiOperation;
@@ -13,13 +14,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static com.firstone.greenjangteo.utility.PagingConstant.*;
 import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
 
 @RestController
@@ -54,17 +55,19 @@ public class CouponGroupController {
     public ResponseEntity<CouponGroupResponseDto> getCouponGroup
             (@PathVariable("couponGroupId")
              @ApiParam(value = COUPON_GROUP_ID, example = ID_EXAMPLE) String couponGroupId,
-             @RequestParam(defaultValue = "true")
-             @ApiParam(value = "페이지네이션 사용 여부", example = "true") boolean paged,
-             @RequestParam(defaultValue = "0")
-             @ApiParam(value = "현재 페이지 번호", example = "0") int page,
-             @RequestParam(defaultValue = "20")
-             @ApiParam(value = "페이지 당 항목 수", example = "20") int size,
-             @RequestParam(defaultValue = "id,asc")
-             @ApiParam(value = "정렬 방식", example = "id,asc") String sort) {
+             @RequestParam(defaultValue = TRUE)
+             @ApiParam(value = IS_PAGINATION_USED, example = TRUE) boolean paged,
+             @RequestParam(defaultValue = ZERO)
+             @ApiParam(value = CURRENT_PAGE_NUMBER, example = ZERO) int page,
+             @RequestParam(defaultValue = TWENTY)
+             @ApiParam(value = NUMBER_OF_ITEMS_PER_PAGE, example = TWENTY) int size,
+             @RequestParam(defaultValue = ORDER_BY_ID_ASCENDING)
+             @ApiParam(value = SORTING_METHOD, example = ORDER_BY_ID_ASCENDING) String sort) {
         InputFormatValidator.validateId(couponGroupId);
         RoleValidator.checkAdminAuthentication();
-        Pageable pageable = paged ? PageRequest.of(page, size, parseSortString(sort)) : Pageable.unpaged();
+        Pageable pageable = paged
+                ? PageRequest.of(page, size, FormatConverter.parseSortString(sort))
+                : Pageable.unpaged();
 
         Page<Coupon> couponPage = couponGroupService.getCouponGroup(Long.parseLong(couponGroupId), pageable);
         return ResponseEntity.status(HttpStatus.OK)
@@ -82,10 +85,5 @@ public class CouponGroupController {
         couponGroupService.deleteCouponGroup(Long.parseLong(couponGroupId));
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
-
-    private Sort parseSortString(String sort) {
-        String[] parts = sort.split(",");
-        return Sort.by(Sort.Direction.fromString(parts[1]), parts[0]);
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/post/aop/PostLoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/post/aop/PostLoggingAspect.java
@@ -7,6 +7,7 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 
@@ -23,6 +24,13 @@ public class PostLoggingAspect {
             = "Beginning to '{}.{}' task by userId: '{}', subject: '{}'";
     private static final String CREATE_POST_END
             = "'{}.{}' task was executed successfully by 'userId: {}', subject: '{}', ";
+
+    private static final String GET_ALL_POSTS_POINTCUT
+            = "execution(* com.firstone.greenjangteo.post.service.*.*(..)) && args(pageable)";
+    private static final String GET_ALL_POSTS_START
+            = "Beginning to '{}.{}' task by page: '{}'";
+    private static final String GET_ALL_POSTS_END
+            = "'{}.{}' task was executed successfully by 'page: {}', ";
 
     @Around(CREATE_POST_POINTCUT)
     public Object logAroundForPostRequestDto(ProceedingJoinPoint joinPoint,
@@ -43,6 +51,29 @@ public class PostLoggingAspect {
         log.info(CREATE_POST_END + PERFORMANCE_MEASUREMENT,
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), postRequestDto.getUserId(), postRequestDto.getSubject(),
+                stopWatch.getTotalTimeMillis(), memoryUsage);
+
+        return process;
+    }
+
+    @Around(GET_ALL_POSTS_POINTCUT)
+    public Object logAroundForPageable(ProceedingJoinPoint joinPoint, Pageable pageable) throws Throwable {
+        log.info(GET_ALL_POSTS_START,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(), pageable.getPageNumber());
+
+        long beforeMemory = MemoryUtil.usedMemory();
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        Object process = joinPoint.proceed();
+
+        stopWatch.stop();
+        long memoryUsage = MemoryUtil.usedMemory() - beforeMemory;
+
+        log.info(GET_ALL_POSTS_END + PERFORMANCE_MEASUREMENT,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(), pageable.getPageNumber(),
                 stopWatch.getTotalTimeMillis(), memoryUsage);
 
         return process;

--- a/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
+++ b/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
@@ -4,13 +4,17 @@ import com.firstone.greenjangteo.post.domain.view.model.entity.View;
 import com.firstone.greenjangteo.post.domain.view.model.service.ViewService;
 import com.firstone.greenjangteo.post.dto.PostRequestDto;
 import com.firstone.greenjangteo.post.dto.PostResponseDto;
+import com.firstone.greenjangteo.post.dto.PostsResponseDto;
 import com.firstone.greenjangteo.post.model.entity.Post;
 import com.firstone.greenjangteo.post.service.PostService;
+import com.firstone.greenjangteo.utility.FormatConverter;
 import com.firstone.greenjangteo.utility.InputFormatValidator;
 import com.firstone.greenjangteo.utility.RoleValidator;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +23,10 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.validation.Valid;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
+import static com.firstone.greenjangteo.utility.PagingConstant.*;
 import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
 
 @RestController
@@ -33,10 +40,14 @@ public class PostController {
     private static final String CREATE_POST_DESCRIPTION = "회원 ID와 게시물 내용을 입력해 게시물을 등록할 수 있습니다.";
     private static final String CREATE_POST_FORM = "게시물 등록 양식";
 
+    private static final String GET_ALL_POSTS = "게시글 목록 조회";
+    private static final String GET_ALL_POSTS_DESCRIPTION = "전체 게시글 목록을 조회할 수 있습니다." +
+            "\n페이징 옵션을 선택할 수 있습니다.";
+
     private static final String GET_POST = "게시물 조회";
     private static final String GET_POST_DESCRIPTION = "게시물 ID와 게시자 ID를 입력해 게시물을 조회할 수 있습니다.";
-    private static final String WRITER_ID = "게시자 ID";
     private static final String POST_ID = "게시물 ID";
+    private static final String WRITER_ID = "게시자 ID";
 
     @ApiOperation(value = CREATE_POST, notes = CREATE_POST_DESCRIPTION)
     @PostMapping
@@ -49,6 +60,50 @@ public class PostController {
 
         return buildResponse(PostResponseDto.from(post));
     }
+
+    @ApiOperation(value = GET_ALL_POSTS, notes = GET_ALL_POSTS_DESCRIPTION)
+    @GetMapping()
+    public ResponseEntity<List<PostsResponseDto>> getAllPosts
+            (@RequestParam(defaultValue = TRUE)
+             @ApiParam(value = IS_PAGINATION_USED, example = TRUE) boolean paged,
+             @RequestParam(defaultValue = ZERO)
+             @ApiParam(value = CURRENT_PAGE_NUMBER, example = ZERO) int page,
+             @RequestParam(defaultValue = FIVE)
+             @ApiParam(value = NUMBER_OF_ITEMS_PER_PAGE, example = FIVE) int size,
+             @RequestParam(defaultValue = ORDER_BY_ID_ASCENDING)
+             @ApiParam(value = SORTING_METHOD, example = ORDER_BY_CREATED_AT_DESCENDING) String sort) {
+        Pageable pageable = paged
+                ? PageRequest.of(page, size, FormatConverter.parseSortString(sort))
+                : Pageable.unpaged();
+
+        List<Post> posts = postService.getPosts(pageable).getContent();
+
+        List<PostsResponseDto> postsResponseDtos = convertPostsToPostsResponseDtos(posts);
+
+        return ResponseEntity.status(HttpStatus.OK).body(postsResponseDtos);
+    }
+
+//    @ApiOperation(value = GET_ALL_POSTS, notes = GET_ALL_POSTS_DESCRIPTION)
+//    @GetMapping()
+//    public ResponseEntity<Page<PostResponseDto>> getAllPosts
+//            (@PathVariable("couponGroupId")
+//             @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId,
+//             @RequestParam(defaultValue = TRUE)
+//             @ApiParam(value = IS_PAGINATION_USED, example = TRUE) boolean paged,
+//             @RequestParam(defaultValue = ZERO)
+//             @ApiParam(value = CURRENT_PAGE_NUMBER, example = ZERO) int page,
+//             @RequestParam(defaultValue = FIVE)
+//             @ApiParam(value = NUMBER_OF_ITEMS_PER_PAGE, example = FIVE) int size,
+//             @RequestParam(defaultValue = ORDER_BY_ID_ASCENDING)
+//             @ApiParam(value = SORTING_METHOD, example = ORDER_BY_ID_DESCENDING) String sort) {
+//        InputFormatValidator.validateId(couponGroupId);
+//        RoleValidator.checkAdminAuthentication();
+//        Pageable pageable = paged ? PageRequest.of(page, size, parseSortString(sort)) : Pageable.unpaged();
+//
+//        Page<Coupon> couponPage = couponGroupService.getCouponGroup(Long.parseLong(couponGroupId), pageable);
+//        return ResponseEntity.status(HttpStatus.OK)
+//                .body(CouponAndGroupEntityToDtoMapper.toCouponGroupResponseDto(couponPage));
+//    }
 
     @ApiOperation(value = GET_POST, notes = GET_POST_DESCRIPTION)
     @GetMapping("/{postId}")
@@ -75,5 +130,16 @@ public class PostController {
         headers.setLocation(location);
 
         return ResponseEntity.status(HttpStatus.CREATED).headers(headers).body(postResponseDto);
+    }
+
+    private List<PostsResponseDto> convertPostsToPostsResponseDtos(List<Post> posts) {
+        List<PostsResponseDto> postsResponseDtos = new ArrayList<>();
+        for (Post post : posts) {
+            View view = viewService.getView(post.getId());
+            PostsResponseDto postsResponseDto = PostsResponseDto.from(post, view.getViewCount());
+            postsResponseDtos.add(postsResponseDto);
+        }
+
+        return postsResponseDtos;
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
+++ b/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
@@ -83,28 +83,6 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.OK).body(postsResponseDtos);
     }
 
-//    @ApiOperation(value = GET_ALL_POSTS, notes = GET_ALL_POSTS_DESCRIPTION)
-//    @GetMapping()
-//    public ResponseEntity<Page<PostResponseDto>> getAllPosts
-//            (@PathVariable("couponGroupId")
-//             @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId,
-//             @RequestParam(defaultValue = TRUE)
-//             @ApiParam(value = IS_PAGINATION_USED, example = TRUE) boolean paged,
-//             @RequestParam(defaultValue = ZERO)
-//             @ApiParam(value = CURRENT_PAGE_NUMBER, example = ZERO) int page,
-//             @RequestParam(defaultValue = FIVE)
-//             @ApiParam(value = NUMBER_OF_ITEMS_PER_PAGE, example = FIVE) int size,
-//             @RequestParam(defaultValue = ORDER_BY_ID_ASCENDING)
-//             @ApiParam(value = SORTING_METHOD, example = ORDER_BY_ID_DESCENDING) String sort) {
-//        InputFormatValidator.validateId(couponGroupId);
-//        RoleValidator.checkAdminAuthentication();
-//        Pageable pageable = paged ? PageRequest.of(page, size, parseSortString(sort)) : Pageable.unpaged();
-//
-//        Page<Coupon> couponPage = couponGroupService.getCouponGroup(Long.parseLong(couponGroupId), pageable);
-//        return ResponseEntity.status(HttpStatus.OK)
-//                .body(CouponAndGroupEntityToDtoMapper.toCouponGroupResponseDto(couponPage));
-//    }
-
     @ApiOperation(value = GET_POST, notes = GET_POST_DESCRIPTION)
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponseDto> getPost

--- a/src/main/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewService.java
@@ -15,4 +15,8 @@ public class ViewService {
         view.addViewCount();
         return viewRepository.save(view);
     }
+
+    public View getView(Long postId) {
+        return viewRepository.findById(postId).orElse(new View(postId));
+    }
 }

--- a/src/main/java/com/firstone/greenjangteo/post/dto/PostsResponseDto.java
+++ b/src/main/java/com/firstone/greenjangteo/post/dto/PostsResponseDto.java
@@ -1,0 +1,43 @@
+package com.firstone.greenjangteo.post.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.firstone.greenjangteo.post.model.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostsResponseDto {
+    private Long postId;
+    private String username;
+    private String subject;
+    private int viewCount;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime createdAt;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime modifiedAt;
+
+    public static PostsResponseDto from(Post post, int viewCount) {
+        return PostsResponseDto.builder()
+                .postId(post.getId())
+                .username(post.getUser().getUsername().getValue())
+                .subject(post.getSubject())
+                .viewCount(viewCount)
+                .createdAt(post.getCreatedAt())
+                .modifiedAt(post.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/post/repository/PostRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/repository/PostRepository.java
@@ -1,10 +1,14 @@
 package com.firstone.greenjangteo.post.repository;
 
 import com.firstone.greenjangteo.post.model.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Page<Post> findAll(Pageable pageable);
+
     Optional<Post> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostService.java
@@ -2,9 +2,13 @@ package com.firstone.greenjangteo.post.service;
 
 import com.firstone.greenjangteo.post.dto.PostRequestDto;
 import com.firstone.greenjangteo.post.model.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface PostService {
     Post createPost(PostRequestDto postRegisterDto);
+
+    Page<Post> getPosts(Pageable pageable);
 
     Post getPost(Long postId, Long writerId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
@@ -9,6 +9,8 @@ import com.firstone.greenjangteo.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +53,12 @@ public class PostServiceImpl implements PostService {
         }
 
         return post;
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
+    public Page<Post> getPosts(Pageable pageable) {
+        return postRepository.findAll(pageable);
     }
 
     @Override

--- a/src/main/java/com/firstone/greenjangteo/utility/FormatConverter.java
+++ b/src/main/java/com/firstone/greenjangteo/utility/FormatConverter.java
@@ -1,0 +1,10 @@
+package com.firstone.greenjangteo.utility;
+
+import org.springframework.data.domain.Sort;
+
+public class FormatConverter {
+    public static Sort parseSortString(String sort) {
+        String[] parts = sort.split(",");
+        return Sort.by(Sort.Direction.fromString(parts[1]), parts[0]);
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/utility/PagingConstant.java
+++ b/src/main/java/com/firstone/greenjangteo/utility/PagingConstant.java
@@ -1,0 +1,15 @@
+package com.firstone.greenjangteo.utility;
+
+public class PagingConstant {
+    public static final String IS_PAGINATION_USED = "페이지네이션 사용 여부";
+    public static final String CURRENT_PAGE_NUMBER = "현재 페이지 번호";
+    public static final String NUMBER_OF_ITEMS_PER_PAGE = "페이지 당 항목 수";
+    public static final String SORTING_METHOD = "정렬 방식";
+
+    public static final String TRUE = "true";
+    public static final String ZERO = "0";
+    public static final String FIVE = "5";
+    public static final String TWENTY = "20";
+    public static final String ORDER_BY_ID_ASCENDING = "id,asc";
+    public static final String ORDER_BY_CREATED_AT_DESCENDING = "createdAt,desc";
+}

--- a/src/test/java/com/firstone/greenjangteo/coupon/controller/CouponGroupControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/coupon/controller/CouponGroupControllerTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static com.firstone.greenjangteo.coupon.testutil.CouponTestConstant.*;
+import static com.firstone.greenjangteo.utility.PagingConstant.*;
 import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -96,10 +97,10 @@ public class CouponGroupControllerTest {
 
         // when, then
         mockMvc.perform(get("/coupon-groups/{couponGroupId}", ID_EXAMPLE)
-                        .param("paged", "true")
-                        .param("page", "0")
-                        .param("size", "20")
-                        .param("sort", "id,asc"))
+                        .param("paged", TRUE)
+                        .param("page", ZERO)
+                        .param("size", TWENTY)
+                        .param("sort", ORDER_BY_ID_ASCENDING))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/firstone/greenjangteo/post/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/image/service/ImageServiceTest.java
@@ -17,8 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.firstone.greenjangteo.post.domain.image.testutil.ImageTestConstant.*;
-import static com.firstone.greenjangteo.post.utility.PostTestConstant.CONTENT;
-import static com.firstone.greenjangteo.post.utility.PostTestConstant.SUBJECT;
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.CONTENT1;
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.SUBJECT1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
@@ -39,7 +39,7 @@ class ImageServiceTest {
     @Test
     void saveImages() {
         // given
-        Post post = PostTestObjectFactory.createPost(SUBJECT, CONTENT);
+        Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
         postRepository.save(post);
 
         List<ImageRequestDto> imageRequestDtos = ImageTestObjectFactory.createImageRequestDtos();

--- a/src/test/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewServiceTest.java
@@ -9,8 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import static com.firstone.greenjangteo.post.utility.PostTestConstant.CONTENT;
-import static com.firstone.greenjangteo.post.utility.PostTestConstant.SUBJECT;
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.CONTENT1;
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.SUBJECT1;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @ActiveProfiles("test")
@@ -22,11 +22,11 @@ class ViewServiceTest {
     @Autowired
     private PostRepository postRepository;
 
-    @DisplayName("조회수를 추가하고 조회할 수 있다.")
+    @DisplayName("게시물 ID를 전송해 조회수를 추가하고 조회수 객체를 생성하거나 조회할 수 있다.")
     @Test
     void addAndGetView() {
         // given
-        Post post = PostTestObjectFactory.createPost(SUBJECT, CONTENT);
+        Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
         postRepository.save(post);
 
         // when
@@ -38,5 +38,22 @@ class ViewServiceTest {
         assertThat(viewCount1).isEqualTo(1);
         assertThat(viewCount2).isEqualTo(2);
         assertThat(viewCount3).isEqualTo(3);
+    }
+
+    @DisplayName("게시물 ID를 전송해 조회수 객체를 생성하거나 조회할 수 있다.")
+    @Test
+    void getView() {
+        // given
+        Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
+        postRepository.save(post);
+
+        // when
+        int viewCount1 = viewService.getView(post.getId()).getViewCount();
+        viewService.addAndGetView(post.getId());
+        int viewCount2 = viewService.getView(post.getId()).getViewCount();
+
+        // then
+        assertThat(viewCount1).isEqualTo(0);
+        assertThat(viewCount2).isEqualTo(1);
     }
 }

--- a/src/test/java/com/firstone/greenjangteo/post/utility/PostTestConstant.java
+++ b/src/test/java/com/firstone/greenjangteo/post/utility/PostTestConstant.java
@@ -2,6 +2,12 @@ package com.firstone.greenjangteo.post.utility;
 
 public class PostTestConstant {
     public static final String POST_ID = "1";
-    public static final String SUBJECT = "제목";
-    public static final String CONTENT = "내용";
+
+    public static final String SUBJECT1 = "제목1";
+    public static final String SUBJECT2 = "제목2";
+    public static final String SUBJECT3 = "제목3";
+
+    public static final String CONTENT1 = "내용1";
+    public static final String CONTENT2 = "내용2";
+    public static final String CONTENT3 = "내용3";
 }


### PR DESCRIPTION
## resolve #209

## 추가사항

### 프로덕션 코드
- 전체 게시글 목록 조회 요청
- 전체 게시글 목록 조회 비즈니스 로직
- 전체 게시글 목록을 페이징 처리하고 생성 순서 내림차순으로 정렬해 조회
- 각 게시물의 조회 수 조회 비즈니스 로직
- 200 status code 반환
- 페이징 옵션을 별도의 클래스 상수로 분리
- FormatConverter 클래스 추가
    - 정렬 방식 정보를 파싱하는 메서드를 별도의 클래스로 분리

### 테스트 코드
- 전체 게시글 목록 조회 요청, 200 status code 응답
- 전체 게시글 목록 조회 비즈니스 로직
- 전체 게시글 목록을 페이징 처리하고 생성 순서 내림차순으로 정렬해 조회
- 각 게시물의 조회 수 조회 비즈니스 로직