### PR TITLE
[#211] 자신의 게시글 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/aop/LoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/aop/LoggingAspect.java
@@ -8,6 +8,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.CodeSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 
@@ -25,7 +26,7 @@ public class LoggingAspect {
             = "execution(* com.firstone.greenjangteo..service.*.*(..)) && args(longValue, ..)";
 
     private static final String START
-            = "Beginning to '{}.{}' task by {}: '{}'";
+            = "Beginning to '{}.{}' task by '{}: {}'";
     private static final String END
             = "'{}.{}' task was executed successfully by '{}: {}', ";
 
@@ -39,9 +40,16 @@ public class LoggingAspect {
     private static final String USER_ID_REQUEST_DTO_POINTCUT
             = "execution(* com.firstone.greenjangteo..service.*.*(..)) && args(userIdRequestDto)";
     private static final String USER_ID_REQUEST_DTO_START
-            = "Beginning to '{}.{}' task by userId: '{}', ";
+            = "Beginning to '{}.{}' task by 'userId: {}', ";
     private static final String USER_ID_REQUEST_DTO_END
             = "'{}.{}' task was executed successfully by 'userId: {}', ";
+
+    private static final String PAGEABLE_AND_ID_POINTCUT
+            = "execution(* com.firstone.greenjangteo..service.*.*(..)) && args(pageable, longValue)";
+    private static final String PAGEABLE_AND_ID_START
+            = "Beginning to '{}.{}' task by 'page: {}', '{}: {}'";
+    private static final String PAGEABLE_AND_ID_END
+            = "'{}.{}' task was executed successfully by 'page: {}', '{}: {}', ";
 
     @Around(STRING_VALUE_POINTCUT)
     public Object logAroundForStringValue(ProceedingJoinPoint joinPoint, String stringValue) throws Throwable {
@@ -135,6 +143,32 @@ public class LoggingAspect {
         log.info(USER_ID_REQUEST_DTO_END + PERFORMANCE_MEASUREMENT,
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), userIdRequestDto.getUserId(),
+                stopWatch.getTotalTimeMillis(), memoryUsage);
+
+        return process;
+    }
+
+    @Around(PAGEABLE_AND_ID_POINTCUT)
+    public Object logAroundForPageableAndId(ProceedingJoinPoint joinPoint, Pageable pageable, Long longValue)
+            throws Throwable {
+        String parameterName = ((CodeSignature) joinPoint.getSignature()).getParameterNames()[1];
+
+        log.info(PAGEABLE_AND_ID_START,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(), pageable.getPageNumber(), parameterName, longValue);
+
+        long beforeMemory = MemoryUtil.usedMemory();
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        Object process = joinPoint.proceed();
+
+        stopWatch.stop();
+        long memoryUsage = MemoryUtil.usedMemory() - beforeMemory;
+
+        log.info(PAGEABLE_AND_ID_END + PERFORMANCE_MEASUREMENT,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(), pageable.getPageNumber(), parameterName, longValue,
                 stopWatch.getTotalTimeMillis(), memoryUsage);
 
         return process;

--- a/src/main/java/com/firstone/greenjangteo/coupon/controller/CouponGroupController.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/controller/CouponGroupController.java
@@ -69,7 +69,7 @@ public class CouponGroupController {
                 ? PageRequest.of(page, size, FormatConverter.parseSortString(sort))
                 : Pageable.unpaged();
 
-        Page<Coupon> couponPage = couponGroupService.getCouponGroup(Long.parseLong(couponGroupId), pageable);
+        Page<Coupon> couponPage = couponGroupService.getCouponGroup(pageable, Long.parseLong(couponGroupId));
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CouponAndGroupEntityToDtoMapper.toCouponGroupResponseDto(couponPage));
     }

--- a/src/main/java/com/firstone/greenjangteo/coupon/service/CouponGroupService.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/service/CouponGroupService.java
@@ -13,7 +13,7 @@ public interface CouponGroupService {
 
     List<CouponGroup> getCouponGroups();
 
-    Page<Coupon> getCouponGroup(Long couponGroupId, Pageable pageable);
+    Page<Coupon> getCouponGroup(Pageable pageable, Long couponGroupId);
 
     CouponGroup getCouponGroup(String couponName);
 

--- a/src/main/java/com/firstone/greenjangteo/coupon/service/CouponGroupServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/service/CouponGroupServiceImpl.java
@@ -39,7 +39,7 @@ public class CouponGroupServiceImpl implements CouponGroupService {
 
     @Override
     @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
-    public Page<Coupon> getCouponGroup(Long couponGroupId, Pageable pageable) {
+    public Page<Coupon> getCouponGroup(Pageable pageable, Long couponGroupId) {
         if (couponGroupRepository.existsById(couponGroupId)) {
             return couponRepository.findByCouponGroupId(couponGroupId, pageable);
         }

--- a/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
+++ b/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -27,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.firstone.greenjangteo.utility.PagingConstant.*;
-import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
+import static com.firstone.greenjangteo.web.ApiConstant.*;
 
 @RestController
 @RequestMapping("/posts")
@@ -40,8 +41,12 @@ public class PostController {
     private static final String CREATE_POST_DESCRIPTION = "회원 ID와 게시물 내용을 입력해 게시물을 등록할 수 있습니다.";
     private static final String CREATE_POST_FORM = "게시물 등록 양식";
 
-    private static final String GET_ALL_POSTS = "게시글 목록 조회";
+    private static final String GET_ALL_POSTS = "전체 게시글 목록 조회";
     private static final String GET_ALL_POSTS_DESCRIPTION = "전체 게시글 목록을 조회할 수 있습니다." +
+            "\n페이징 옵션을 선택할 수 있습니다.";
+
+    private static final String GET_MY_POSTS = "자신의 게시글 목록 조회";
+    private static final String GET_MY_POSTS_DESCRIPTION = "자신의 게시글 목록을 조회할 수 있습니다." +
             "\n페이징 옵션을 선택할 수 있습니다.";
 
     private static final String GET_POST = "게시물 조회";
@@ -77,6 +82,32 @@ public class PostController {
                 : Pageable.unpaged();
 
         List<Post> posts = postService.getPosts(pageable).getContent();
+
+        List<PostsResponseDto> postsResponseDtos = convertPostsToPostsResponseDtos(posts);
+
+        return ResponseEntity.status(HttpStatus.OK).body(postsResponseDtos);
+    }
+
+    @ApiOperation(value = GET_MY_POSTS, notes = GET_MY_POSTS_DESCRIPTION)
+    @PreAuthorize(PRINCIPAL_POINTCUT)
+    @GetMapping("/my")
+    public ResponseEntity<List<PostsResponseDto>> getMyPosts
+            (@RequestParam(name = "userId")
+             @ApiParam(value = USER_ID_VALUE, example = ID_EXAMPLE) String userId,
+             @RequestParam(defaultValue = TRUE)
+             @ApiParam(value = IS_PAGINATION_USED, example = TRUE) boolean paged,
+             @RequestParam(defaultValue = ZERO)
+             @ApiParam(value = CURRENT_PAGE_NUMBER, example = ZERO) int page,
+             @RequestParam(defaultValue = FIVE)
+             @ApiParam(value = NUMBER_OF_ITEMS_PER_PAGE, example = FIVE) int size,
+             @RequestParam(defaultValue = ORDER_BY_ID_ASCENDING)
+             @ApiParam(value = SORTING_METHOD, example = ORDER_BY_CREATED_AT_DESCENDING) String sort) {
+        InputFormatValidator.validateId(userId);
+        Pageable pageable = paged
+                ? PageRequest.of(page, size, FormatConverter.parseSortString(sort))
+                : Pageable.unpaged();
+
+        List<Post> posts = postService.getPosts(pageable, Long.parseLong(userId)).getContent();
 
         List<PostsResponseDto> postsResponseDtos = convertPostsToPostsResponseDtos(posts);
 

--- a/src/main/java/com/firstone/greenjangteo/post/repository/PostRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/repository/PostRepository.java
@@ -4,11 +4,14 @@ import com.firstone.greenjangteo.post.model.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAll(Pageable pageable);
+
+    Page<Post> findByUserId(@Param("userId") Long userId, Pageable pageable);
 
     Optional<Post> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostService.java
@@ -10,5 +10,7 @@ public interface PostService {
 
     Page<Post> getPosts(Pageable pageable);
 
+    Page<Post> getPosts(Pageable pageable, Long userId);
+
     Post getPost(Long postId, Long writerId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
@@ -62,6 +62,11 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    public Page<Post> getPosts(Pageable pageable, Long userId) {
+        return postRepository.findByUserId(userId, pageable);
+    }
+
+    @Override
     @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 15)
     @Cacheable(key = REQUEST_KEY, condition = GET_KEY_CONDITION, unless = UNLESS_CONDITION, value = KEY_VALUE)
     public Post getPost(Long postId, Long writerId) {

--- a/src/test/java/com/firstone/greenjangteo/coupon/controller/CouponGroupControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/coupon/controller/CouponGroupControllerTest.java
@@ -93,7 +93,7 @@ public class CouponGroupControllerTest {
         Pageable pageable = PageRequest.of(0, 20);
         Page<Coupon> couponPage = new PageImpl<>(coupons, pageable, coupons.size());
 
-        when(couponGroupService.getCouponGroup(eq(1L), any(Pageable.class))).thenReturn(couponPage);
+        when(couponGroupService.getCouponGroup(any(Pageable.class), eq(1L))).thenReturn(couponPage);
 
         // when, then
         mockMvc.perform(get("/coupon-groups/{couponGroupId}", ID_EXAMPLE)

--- a/src/test/java/com/firstone/greenjangteo/coupon/service/CouponGroupServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/coupon/service/CouponGroupServiceTest.java
@@ -76,7 +76,7 @@ public class CouponGroupServiceTest {
         couponRepository.saveAll(createdCoupons);
 
         // when
-        List<Coupon> foundCoupons = couponGroupService.getCouponGroup(createdCouponGroup.getId(), Pageable.ofSize(2))
+        List<Coupon> foundCoupons = couponGroupService.getCouponGroup(Pageable.ofSize(2), createdCouponGroup.getId())
                 .getContent();
 
         // then
@@ -100,7 +100,7 @@ public class CouponGroupServiceTest {
         Pageable pageable = mock(Pageable.class);
 
         // when, then
-        assertThatThrownBy(() -> couponGroupService.getCouponGroup(couponGroupId, pageable))
+        assertThatThrownBy(() -> couponGroupService.getCouponGroup(pageable, couponGroupId))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage(COUPON_GROUP_ID_NOT_FOUND_EXCEPTION + couponGroupId);
     }

--- a/src/test/java/com/firstone/greenjangteo/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/repository/PostRepositoryTest.java
@@ -104,6 +104,33 @@ class PostRepositoryTest {
         // then
         assertThat(posts).hasSize(2)
                 .extracting("subject", "content")
-                .containsExactlyInAnyOrder(tuple(SUBJECT2, CONTENT2), tuple(SUBJECT3, CONTENT3));
+                .containsExactly(tuple(SUBJECT3, CONTENT3), tuple(SUBJECT2, CONTENT2));
+    }
+
+    @DisplayName("자신의 게시글 목록을 페이징 처리해 생성 순서 내림차순으로 검색할 수 있다.")
+    @Test
+    void findByUserId() {
+        // given
+        User user = UserTestObjectFactory.createUser(
+                EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.name())
+        );
+        userRepository.save(user);
+
+        Post post1 = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1, user);
+        Post post2 = PostTestObjectFactory.createPost(SUBJECT2, CONTENT2);
+        Post post3 = PostTestObjectFactory.createPost(SUBJECT3, CONTENT3, user);
+
+        postRepository.saveAll(List.of(post1, post2, post3));
+
+        Sort sort = Sort.by("createdAt").descending();
+        Pageable pageable = PageRequest.of(0, 1, sort);
+
+        // when
+        List<Post> posts = postRepository.findByUserId(user.getId(), pageable).getContent();
+
+        // then
+        assertThat(posts).hasSize(1)
+                .extracting("subject", "content")
+                .containsExactly(tuple(SUBJECT3, CONTENT3));
     }
 }


### PR DESCRIPTION
## resolve #211

## 추가사항

### 프로덕션 코드
- 자신의 게시글 목록 조회 요청
- 자신의 게시글 목록 조회 비즈니스 로직
- 자신의 게시글 목록을 페이징 처리하고 생성 순서 내림차순으로 정렬해 조회
- 200 status code 반환
- 페이징과 ID를 매개변수로 갖는 비즈니스 로직의 로깅 추가

### 테스트 코드
- 자신의 게시글 목록 조회 요청, 200 status code 응답
- 자신의 게시글 목록 조회 비즈니스 로직
- 자신의 게시글 목록을 페이징 처리하고 생성 순서 내림차순으로 정렬해 조회