### PR TITLE
[#213] [#214] Redis Cache를 통한 게시글 조회 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     // json
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
+    // hibernate
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.15.2'
+
     // springfox
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'

--- a/src/main/java/com/firstone/greenjangteo/configuration/CacheConfig.java
+++ b/src/main/java/com/firstone/greenjangteo/configuration/CacheConfig.java
@@ -2,6 +2,7 @@ package com.firstone.greenjangteo.configuration;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.firstone.greenjangteo.hibernate.HibernateCollectionMixIn;
@@ -44,6 +45,7 @@ public class CacheConfig {
         mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
 
         mapper.registerModule(new Jdk8Module());
+        mapper.registerModule(new Hibernate5Module());
         mapper.registerModule(new JavaTimeModule());
 
         mapper.addMixIn(Collection.class, HibernateCollectionMixIn.class);

--- a/src/main/java/com/firstone/greenjangteo/post/repository/PostRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/repository/PostRepository.java
@@ -13,5 +13,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByUserId(@Param("userId") Long userId, Pageable pageable);
 
-    Optional<Post> findByIdAndUserId(Long id, Long userId);
+    Optional<Post> findByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
@@ -31,10 +31,10 @@ public class PostServiceImpl implements PostService {
 
     private final EntityManager entityManager;
 
-    private static final String RESULT_KEY = "#result.id";
+    private static final String CREATE_POST_KEY = "#result.id + '_' + #postRequestDto.userId";
     private static final String CREATE_KEY_CONDITION = "#postRequestDto != null &&#postRequestDto.userId != null";
 
-    private static final String REQUEST_KEY = "#postId";
+    private static final String GET_POST_KEY = "#postId + '_' + #writerId";
     private static final String GET_KEY_CONDITION = "#postId != null && #writerId != null";
 
     private static final String KEY_VALUE = "post";
@@ -42,7 +42,7 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(isolation = READ_UNCOMMITTED, timeout = 20)
-    @CachePut(key = RESULT_KEY, condition = CREATE_KEY_CONDITION, unless = UNLESS_CONDITION, value = KEY_VALUE)
+    @CachePut(key = CREATE_POST_KEY, condition = CREATE_KEY_CONDITION, unless = UNLESS_CONDITION, value = KEY_VALUE)
     public Post createPost(PostRequestDto postRequestDto) {
         User user = userService.getUser(Long.parseLong(postRequestDto.getUserId()));
         Post post = postRepository.save(Post.from(postRequestDto, user));
@@ -68,7 +68,7 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 15)
-    @Cacheable(key = REQUEST_KEY, condition = GET_KEY_CONDITION, unless = UNLESS_CONDITION, value = KEY_VALUE)
+    @Cacheable(key = GET_POST_KEY, condition = GET_KEY_CONDITION, unless = UNLESS_CONDITION, value = KEY_VALUE)
     public Post getPost(Long postId, Long writerId) {
         Post post = postRepository.findByIdAndUserId(postId, writerId)
                 .orElseThrow(() -> new EntityNotFoundException


### PR DESCRIPTION
## resolve #213, #214

## 변경사항
- 게시글 등록 요청의 Cache key 이름에 게시자 ID를 포함하도록 표현식 수정
- 게시글 조회 요청의 Cache key 이름에 게시자 ID를 포함하도록 표현식 수정
- hibernate 5 module 의존성 추가
- hibernate 5 module을 object mapper에 등록