### PR TITLE
[#216] Redis Cache를 통한 게시글 조회에서 이미지 목록을 불러 오지 못하는 문제 해결

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
+++ b/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
@@ -34,7 +34,7 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "post", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "post", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.EAGER)
     @JsonManagedReference
     private List<Image> images;
 


### PR DESCRIPTION
## resolve #216

## 변경사항
- Image 엔티티의 로딩 전략을 EAGER로 변경