### PR TITLE
[#216] [#217] Redis Cache를 통해 조회 시 연관된 엔티티를 로드하지 못하는 문제 해결

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
+++ b/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
 
 import javax.persistence.*;
 import java.util.List;
@@ -30,11 +31,11 @@ public class Post extends BaseEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "post", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "post", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.LAZY)
     @JsonManagedReference
     private List<Image> images;
 
@@ -62,5 +63,11 @@ public class Post extends BaseEntity {
                 .images(images)
                 .user(user)
                 .build();
+    }
+
+    @PostLoad
+    private void init() {
+        Hibernate.initialize(user);
+        Hibernate.initialize(images);
     }
 }


### PR DESCRIPTION
## resolve #216, #217

## 변경사항
- PostLoad 어노테이션을 통해 Post 엔티티를 로드할 때 연관된 Image 엔티티 목록을 초기화하도록 설정
- PostLoad 어노테이션을 통해 Post 엔티티를 로드할 때 연관된 User 엔티티 목록을 초기화하도록 설정