### PR TITLE
[#220] 게시글 수정 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
+++ b/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
@@ -37,9 +37,9 @@ public class PostController {
     private final PostService postService;
     private final ViewService viewService;
 
-    private static final String CREATE_POST = "게시물 등록";
-    private static final String CREATE_POST_DESCRIPTION = "회원 ID와 게시물 내용을 입력해 게시물을 등록할 수 있습니다.";
-    private static final String CREATE_POST_FORM = "게시물 등록 양식";
+    private static final String CREATE_POST = "게시글 등록";
+    private static final String CREATE_POST_DESCRIPTION = "회원 ID와 게시글 내용을 입력해 게시글을 등록할 수 있습니다.";
+    private static final String CREATE_POST_FORM = "게시글 등록 양식";
 
     private static final String GET_ALL_POSTS = "전체 게시글 목록 조회";
     private static final String GET_ALL_POSTS_DESCRIPTION = "전체 게시글 목록을 조회할 수 있습니다." +
@@ -49,10 +49,14 @@ public class PostController {
     private static final String GET_MY_POSTS_DESCRIPTION = "자신의 게시글 목록을 조회할 수 있습니다." +
             "\n페이징 옵션을 선택할 수 있습니다.";
 
-    private static final String GET_POST = "게시물 조회";
-    private static final String GET_POST_DESCRIPTION = "게시물 ID와 게시자 ID를 입력해 게시물을 조회할 수 있습니다.";
-    private static final String POST_ID = "게시물 ID";
+    private static final String GET_POST = "게시글 조회";
+    private static final String GET_POST_DESCRIPTION = "게시글 ID와 게시자 ID를 입력해 게시글을 조회할 수 있습니다.";
+    public static final String POST_ID = "게시글 ID";
     private static final String WRITER_ID = "게시자 ID";
+
+    private static final String UPDATE_POST = "게시글 수정";
+    private static final String UPDATE_POST_DESCRIPTION = "게시글 ID와 회원 ID를 입력해 게시글을 수정할 수 있습니다.";
+    private static final String UPDATE_POST_FORM = "게시글 수정 양식";
 
     @ApiOperation(value = CREATE_POST, notes = CREATE_POST_DESCRIPTION)
     @PostMapping
@@ -124,6 +128,22 @@ public class PostController {
 
         Post post = postService.getPost(Long.parseLong(postId), Long.parseLong(writerId));
         View view = viewService.addAndGetView(post.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(PostResponseDto.from(post, view.getViewCount()));
+    }
+
+    @ApiOperation(value = UPDATE_POST, notes = UPDATE_POST_DESCRIPTION)
+    @PreAuthorize(PRINCIPAL_POINTCUT)
+    @PutMapping("{postId}")
+    public ResponseEntity<PostResponseDto> updatePost
+            (@PathVariable @ApiParam(value = POST_ID, example = ID_EXAMPLE) String postId,
+             @Valid @RequestBody @ApiParam(value = UPDATE_POST_FORM) PostRequestDto postRequestDto) {
+
+        InputFormatValidator.validateId(postId);
+        InputFormatValidator.validateId(postRequestDto.getUserId());
+
+        Post post = postService.updatePost(Long.parseLong(postId), postRequestDto);
+        View view = viewService.getView(post.getId());
 
         return ResponseEntity.status(HttpStatus.OK).body(PostResponseDto.from(post, view.getViewCount()));
     }

--- a/src/main/java/com/firstone/greenjangteo/post/domain/image/dto/ImageRequestDto.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/image/dto/ImageRequestDto.java
@@ -15,7 +15,7 @@ public class ImageRequestDto {
     private static final String URL_EXAMPLE
             = "https://test-images-bucket.s3.us-west-1.amazonaws.com/images/sample1.jpg";
 
-    private static final String POSITION_IN_CONTENT_VALUE = "게시물, 댓글 내용에서 이미지의 위치";
+    private static final String POSITION_IN_CONTENT_VALUE = "게시글, 댓글 내용에서 이미지의 위치";
     private static final String POSITION_IN_CONTENT_EXAMPLE = "10";
 
     @ApiModelProperty(value = URL_VALUE, example = URL_EXAMPLE)

--- a/src/main/java/com/firstone/greenjangteo/post/domain/image/model/repository/ImageRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/image/model/repository/ImageRepository.java
@@ -1,7 +1,0 @@
-package com.firstone.greenjangteo.post.domain.image.model.repository;
-
-import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ImageRepository extends JpaRepository<Image, Long> {
-}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/image/repository/ImageRepository.java
@@ -1,0 +1,21 @@
+package com.firstone.greenjangteo.post.domain.image.repository;
+
+import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    List<Image> findAllByPostIdOrderByIdAsc(Long postId);
+
+    @Modifying
+    @Query("DELETE FROM image i WHERE i.post.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("DELETE FROM image i WHERE i IN :images")
+    void deleteAllInList(@Param("images") List<Image> images);
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/image/service/ImageService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/image/service/ImageService.java
@@ -2,11 +2,12 @@ package com.firstone.greenjangteo.post.domain.image.service;
 
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
-import com.firstone.greenjangteo.post.domain.image.model.repository.ImageRepository;
+import com.firstone.greenjangteo.post.domain.image.repository.ImageRepository;
 import com.firstone.greenjangteo.post.model.entity.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,5 +22,64 @@ public class ImageService {
                 .collect(Collectors.toList());
 
         imageRepository.saveAll(images);
+    }
+
+    /**
+     * 클라이언트가 삭제한 이미지는 image 테이블에서 제거, 추가한 이미지는 image 테이블에 추가
+     *
+     * @param post             이미지 데이터 목록이 저장된 게시글
+     * @param imageRequestDtos 새로 갱신될 이미지 데이터 목록
+     */
+    public void updateImages(Post post, List<ImageRequestDto> imageRequestDtos) {
+        Long postId = post.getId();
+
+        if (imageRequestDtos == null || imageRequestDtos.isEmpty()) {
+            deleteAllPostImages(postId);
+            return;
+        }
+
+        List<Image> images = imageRepository.findAllByPostIdOrderByIdAsc(postId);
+
+        List<Image> imagesToDelete = new ArrayList<>();
+        List<Image> imagesToSave = new ArrayList<>();
+
+        int startingIdx = 0;
+
+        for (ImageRequestDto imageRequestDto : imageRequestDtos) {
+            boolean isSameImage = false;
+
+            for (int i = startingIdx; i < images.size(); i++) {
+                if (checkSameUrlAndPosition(images, imageRequestDto, i)) {
+                    isSameImage = true;
+                    startingIdx = i + 1;
+                    break;
+                } else {
+                    imagesToDelete.add(images.get(i));
+                }
+            }
+
+            if (!isSameImage) {
+                imagesToSave.add(Image.from(post, imageRequestDto));
+            }
+        }
+
+        imageRepository.deleteAllInList(imagesToDelete);
+        imageRepository.saveAll(imagesToSave);
+    }
+
+    private void deleteAllPostImages(Long postId) {
+        imageRepository.deleteByPostId(postId);
+    }
+
+    private boolean checkSameUrlAndPosition(List<Image> images, ImageRequestDto imageRequestDto, int idx) {
+        if (!images.get(idx).getUrl().equals(imageRequestDto.getUrl())) {
+            return false;
+        }
+
+        if (images.get(idx).getPositionInContent() != imageRequestDto.getPositionInContent()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
+++ b/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
@@ -56,12 +56,13 @@ public class Post extends BaseEntity {
                 .build();
     }
 
-    public Post updateFrom(PostRequestDto postRequestDto, User user) {
+    public Post updateFrom(PostRequestDto postRequestDto) {
         return Post.builder()
                 .id(id)
+                .subject(postRequestDto.getSubject())
                 .content(postRequestDto.getContent())
-                .images(images)
                 .user(user)
+                .images(images)
                 .build();
     }
 

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostService.java
@@ -13,4 +13,6 @@ public interface PostService {
     Page<Post> getPosts(Pageable pageable, Long userId);
 
     Post getPost(Long postId, Long writerId);
+
+    Post updatePost(Long postId, PostRequestDto postRequestDto);
 }

--- a/src/test/java/com/firstone/greenjangteo/post/controller/PostControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/controller/PostControllerTest.java
@@ -39,8 +39,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -173,6 +172,31 @@ class PostControllerTest {
         // when, then
         mockMvc.perform(get("/posts/{postId}", POST_ID)
                         .queryParam("writerId", SELLER_ID1))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("게시글 ID와 회원 ID를 전송해 게시글을 수정할 수 있다.")
+    @Test
+    @WithMockUser
+    void updatePost() throws Exception {
+        // given
+        User user = mock(User.class);
+        Post post = PostTestObjectFactory.createPost(Long.parseLong(POST_ID), SUBJECT2, CONTENT2, user);
+        List<ImageRequestDto> imageRequestDtos = ImageTestObjectFactory.createImageRequestDtos();
+        PostRequestDto postRequestDto = PostTestObjectFactory
+                .createPostRequestDto(BUYER_ID, SUBJECT2, CONTENT2, imageRequestDtos);
+        View view = mock(View.class);
+
+        when(postService.updatePost(anyLong(), any(PostRequestDto.class))).thenReturn(post);
+        when(viewService.getView(post.getId())).thenReturn(view);
+        when(user.getUsername()).thenReturn(Username.of(USERNAME1));
+
+        // when, then
+        mockMvc.perform(put("/posts/{postId}", post.getId())
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(postRequestDto))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/firstone/greenjangteo/post/domain/image/model/repository/ImageRepositoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/image/model/repository/ImageRepositoryTest.java
@@ -1,0 +1,95 @@
+package com.firstone.greenjangteo.post.domain.image.model.repository;
+
+import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
+import com.firstone.greenjangteo.post.domain.image.repository.ImageRepository;
+import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
+import com.firstone.greenjangteo.post.model.entity.Post;
+import com.firstone.greenjangteo.post.repository.PostRepository;
+import com.firstone.greenjangteo.post.utility.PostTestObjectFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.firstone.greenjangteo.post.domain.image.testutil.ImageTestConstant.*;
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.CONTENT1;
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.SUBJECT1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class ImageRepositoryTest {
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private ImageRepository imageRepository;
+
+    @DisplayName("전송된 postId를 가지는 게시글의 이미지 목록을 ID 오름차순으로 검색할 수 있다.")
+    @Test
+    void findAllByTargetIdOrderByIdAsc() {
+
+        // given
+        Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
+        postRepository.save(post);
+
+        List<Image> images = ImageTestObjectFactory.createImages(post);
+        imageRepository.saveAll(images);
+
+        // when
+        List<Image> foundImages = imageRepository.findAllByPostIdOrderByIdAsc(post.getId());
+
+        // then
+        assertThat(foundImages).hasSize(3)
+                .extracting("url", "positionInContent")
+                .containsExactly(
+                        tuple(IMAGE_URL1, POSITION_IN_CONTENT),
+                        tuple(IMAGE_URL2, POSITION_IN_CONTENT + 1),
+                        tuple(IMAGE_URL3, POSITION_IN_CONTENT + 2)
+                );
+    }
+
+    @DisplayName("게시글 ID를 전송해 게시글의 이미지들을 삭제할 수 있다.")
+    @Test
+    void deleteByPostId() {
+        // given
+        Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
+        postRepository.save(post);
+
+        List<Image> createdImages = ImageTestObjectFactory.createImages(post);
+        imageRepository.saveAll(createdImages);
+
+        Long postId = post.getId();
+
+        // when
+        imageRepository.deleteByPostId(postId);
+        List<Image> foundImages = imageRepository.findAllByPostIdOrderByIdAsc(postId);
+
+        // then
+        assertThat(foundImages).isEmpty();
+    }
+
+    @DisplayName("이미지 목록을 전송해 게시글의 이미지들을 삭제할 수 있다.")
+    @Test
+    void deleteAllInList() {
+        // given
+        Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
+        postRepository.save(post);
+
+        List<Image> createdImages = ImageTestObjectFactory.createImages(post);
+        imageRepository.saveAll(createdImages);
+
+        // when
+        imageRepository.deleteAllInList(createdImages);
+        List<Image> foundImages = imageRepository.findAllByPostIdOrderByIdAsc(post.getId());
+
+        // then
+        assertThat(foundImages).isEmpty();
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/post/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/image/service/ImageServiceTest.java
@@ -2,7 +2,7 @@ package com.firstone.greenjangteo.post.domain.image.service;
 
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
-import com.firstone.greenjangteo.post.domain.image.model.repository.ImageRepository;
+import com.firstone.greenjangteo.post.domain.image.repository.ImageRepository;
 import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
 import com.firstone.greenjangteo.post.model.entity.Post;
 import com.firstone.greenjangteo.post.repository.PostRepository;

--- a/src/test/java/com/firstone/greenjangteo/post/domain/image/testutil/ImageTestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/image/testutil/ImageTestObjectFactory.java
@@ -19,6 +19,16 @@ public class ImageTestObjectFactory {
         return List.of(imageRequestDto1, imageRequestDto2, imageRequestDto3);
     }
 
+    public static List<ImageRequestDto> createImageUpdateRequestDtos() {
+        int position = POSITION_IN_CONTENT;
+
+        ImageRequestDto imageRequestDto2 = createImageRequestDto(IMAGE_URL3, position++);
+        ImageRequestDto imageRequestDto3 = createImageRequestDto(IMAGE_URL2, ++position);
+        ImageRequestDto imageRequestDto1 = createImageRequestDto(IMAGE_URL1, ++position);
+
+        return List.of(imageRequestDto1, imageRequestDto2, imageRequestDto3);
+    }
+
     public static List<Image> createImages(Post post) {
         int position = POSITION_IN_CONTENT;
 

--- a/src/test/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/view/model/service/ViewServiceTest.java
@@ -22,7 +22,7 @@ class ViewServiceTest {
     @Autowired
     private PostRepository postRepository;
 
-    @DisplayName("게시물 ID를 전송해 조회수를 추가하고 조회수 객체를 생성하거나 조회할 수 있다.")
+    @DisplayName("게시글 ID를 전송해 조회수를 추가하고 조회수 객체를 생성하거나 조회할 수 있다.")
     @Test
     void addAndGetView() {
         // given
@@ -40,7 +40,7 @@ class ViewServiceTest {
         assertThat(viewCount3).isEqualTo(3);
     }
 
-    @DisplayName("게시물 ID를 전송해 조회수 객체를 생성하거나 조회할 수 있다.")
+    @DisplayName("게시글 ID를 전송해 조회수 객체를 생성하거나 조회할 수 있다.")
     @Test
     void getView() {
         // given

--- a/src/test/java/com/firstone/greenjangteo/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/repository/PostRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.firstone.greenjangteo.post.repository;
 
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
-import com.firstone.greenjangteo.post.domain.image.model.repository.ImageRepository;
+import com.firstone.greenjangteo.post.domain.image.repository.ImageRepository;
 import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
 import com.firstone.greenjangteo.post.model.entity.Post;
 import com.firstone.greenjangteo.post.utility.PostTestObjectFactory;

--- a/src/test/java/com/firstone/greenjangteo/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/repository/PostRepositoryTest.java
@@ -87,7 +87,7 @@ class PostRepositoryTest {
 
     @DisplayName("모든 게시글 목록을 페이징 처리해 생성 순서 내림차순으로 검색할 수 있다.")
     @Test
-    void findAll() {
+    void findAllWithPaging() {
         // given
         Post post1 = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
         Post post2 = PostTestObjectFactory.createPost(SUBJECT2, CONTENT2);
@@ -109,7 +109,7 @@ class PostRepositoryTest {
 
     @DisplayName("자신의 게시글 목록을 페이징 처리해 생성 순서 내림차순으로 검색할 수 있다.")
     @Test
-    void findByUserId() {
+    void findByUserIdWithPaging() {
         // given
         User user = UserTestObjectFactory.createUser(
                 EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.name())

--- a/src/test/java/com/firstone/greenjangteo/post/service/PostServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/service/PostServiceTest.java
@@ -2,7 +2,7 @@ package com.firstone.greenjangteo.post.service;
 
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
-import com.firstone.greenjangteo.post.domain.image.model.repository.ImageRepository;
+import com.firstone.greenjangteo.post.domain.image.repository.ImageRepository;
 import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
 import com.firstone.greenjangteo.post.dto.PostRequestDto;
 import com.firstone.greenjangteo.post.model.entity.Post;
@@ -71,7 +71,7 @@ class PostServiceTest {
         Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection().flushDb();
     }
 
-    @DisplayName("사용자 ID와 게시글 제목, 내용을 전송해 이미지가 없는 게시물을 등록할 수 있다.")
+    @DisplayName("사용자 ID와 게시글 제목, 내용을 전송해 이미지가 없는 게시글을 등록할 수 있다.")
     @ParameterizedTest
     @CsvSource({
             "안녕하세요?, 12345",
@@ -190,7 +190,7 @@ class PostServiceTest {
                 .containsExactly(tuple(SUBJECT3, CONTENT3), tuple((SUBJECT1), CONTENT1));
     }
 
-    @DisplayName("게시물 ID와 게시자 ID를 전송해 게시글과 이미지들을 조회할 수 있다.")
+    @DisplayName("게시글 ID와 게시자 ID를 전송해 게시글과 이미지들을 조회할 수 있다.")
     @ParameterizedTest
     @CsvSource({
             "안녕하세요?, 12345",


### PR DESCRIPTION
## resolve #220

## 추가사항

### 프로덕션 코드
- 게시글 수정 요청
- 게시글 수정 비즈니스 로직
- 이미지 수정 비즈니스 로직
- 게시글 ID를 통한 이미지 데이터 ID 오름차순 검색
- 게시글 ID를 통한 이미지 데이터 삭제
- 이미지 엔티티 목록을 통한 이미지 데이터 삭제
- 200 status code 반환

### 테스트 코드
- 게시글 수정 요청, 200 status code 응답
- 게시글 수정 비즈니스 로직
- 이미지 수정 비즈니스 로직
- 게시글 ID를 통한 이미지 데이터 ID 오름차순 검색
- 게시글 ID를 통한 이미지 데이터 삭제
- 이미지 엔티티 목록을 통한 이미지 데이터 삭제

## 변경사항
-  Post 도메인의 이름을 게시글로 통일
- ImageRepository 인터페이스의 패키지 이동