### PR TITLE
[#225] 댓글 등록 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/post/aop/CommentLoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/post/aop/CommentLoggingAspect.java
@@ -1,0 +1,50 @@
+package com.firstone.greenjangteo.post.aop;
+
+import com.firstone.greenjangteo.post.domain.comment.dto.CommentRequestDto;
+import com.firstone.greenjangteo.utility.MemoryUtil;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+import static com.firstone.greenjangteo.aop.LogConstant.PERFORMANCE_MEASUREMENT;
+
+@Component
+@Aspect
+public class CommentLoggingAspect {
+    private static final Logger log = LoggerFactory.getLogger(CommentLoggingAspect.class);
+
+    private static final String CREATE_COMMENT_POINTCUT
+            = "execution(* com.firstone.greenjangteo.post.domain.comment.service.*.*(..)) && args(commentRequestDto)";
+    private static final String CREATE_COMMENT_START
+            = "Beginning to '{}.{}' task by userId: '{}', content: '{}'";
+    private static final String CREATE_COMMENT_END
+            = "'{}.{}' task was executed successfully by userId: '{}', content: '{}', ";
+
+    @Around(CREATE_COMMENT_POINTCUT)
+    public Object logAroundForCommentRequestDto(ProceedingJoinPoint joinPoint,
+                                                CommentRequestDto commentRequestDto) throws Throwable {
+        log.info(CREATE_COMMENT_START,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(), commentRequestDto.getUserId(), commentRequestDto.getContent());
+
+        long beforeMemory = MemoryUtil.usedMemory();
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        Object process = joinPoint.proceed();
+
+        stopWatch.stop();
+        long memoryUsage = MemoryUtil.usedMemory() - beforeMemory;
+
+        log.info(CREATE_COMMENT_END + PERFORMANCE_MEASUREMENT,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(), commentRequestDto.getUserId(), commentRequestDto.getContent(),
+                stopWatch.getTotalTimeMillis(), memoryUsage);
+
+        return process;
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/post/aop/ImageLoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/post/aop/ImageLoggingAspect.java
@@ -1,5 +1,6 @@
 package com.firstone.greenjangteo.post.aop;
 
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
 import com.firstone.greenjangteo.post.model.entity.Post;
 import com.firstone.greenjangteo.utility.MemoryUtil;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -17,16 +18,23 @@ import static com.firstone.greenjangteo.aop.LogConstant.PERFORMANCE_MEASUREMENT;
 public class ImageLoggingAspect {
     private static final Logger log = LoggerFactory.getLogger(ImageLoggingAspect.class);
 
-    private static final String SAVE_IMAGES_POINTCUT
+    private static final String SAVE_POST_IMAGES_POINTCUT
             = "execution(* com.firstone.greenjangteo.post.domain.image.service.*.*(..)) && args(post, ..)";
-    private static final String SAVE_IMAGES_START
+    private static final String SAVE_POST_IMAGES_START
             = "Beginning to '{}.{}' task by postId: '{}'";
-    private static final String SAVE_IMAGES_END
-            = "'{}.{}' task was executed successfully by 'postId: {}', ";
+    private static final String SAVE_POST_IMAGES_END
+            = "'{}.{}' task was executed successfully by postId: '{}', ";
 
-    @Around(SAVE_IMAGES_POINTCUT)
+    private static final String SAVE_COMMENT_IMAGES_POINTCUT
+            = "execution(* com.firstone.greenjangteo.post.domain.image.service.*.*(..)) && args(comment, ..)";
+    private static final String SAVE_COMMENT_IMAGES_START
+            = "Beginning to '{}.{}' task by commentId: '{}'";
+    private static final String SAVE_COMMENT_IMAGES_END
+            = "'{}.{}' task was executed successfully by commentId: '{}', ";
+
+    @Around(SAVE_POST_IMAGES_POINTCUT)
     public Object logAroundForPostAndImageRequestDtos(ProceedingJoinPoint joinPoint, Post post) throws Throwable {
-        log.info(SAVE_IMAGES_START,
+        log.info(SAVE_POST_IMAGES_START,
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), post.getId());
 
@@ -39,9 +47,33 @@ public class ImageLoggingAspect {
         stopWatch.stop();
         long memoryUsage = MemoryUtil.usedMemory() - beforeMemory;
 
-        log.info(SAVE_IMAGES_END + PERFORMANCE_MEASUREMENT,
+        log.info(SAVE_POST_IMAGES_END + PERFORMANCE_MEASUREMENT,
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), post.getId(),
+                stopWatch.getTotalTimeMillis(), memoryUsage);
+
+        return process;
+    }
+
+    @Around(SAVE_COMMENT_IMAGES_POINTCUT)
+    public Object logAroundForCommentAndImageRequestDtos(ProceedingJoinPoint joinPoint, Comment comment)
+            throws Throwable {
+        log.info(SAVE_COMMENT_IMAGES_START,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(), comment.getId());
+
+        long beforeMemory = MemoryUtil.usedMemory();
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        Object process = joinPoint.proceed();
+
+        stopWatch.stop();
+        long memoryUsage = MemoryUtil.usedMemory() - beforeMemory;
+
+        log.info(SAVE_COMMENT_IMAGES_END + PERFORMANCE_MEASUREMENT,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(), comment.getId(),
                 stopWatch.getTotalTimeMillis(), memoryUsage);
 
         return process;

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentController.java
@@ -1,0 +1,58 @@
+package com.firstone.greenjangteo.post.domain.comment.controller;
+
+import com.firstone.greenjangteo.post.domain.comment.dto.CommentRequestDto;
+import com.firstone.greenjangteo.post.domain.comment.dto.CommentResponseDto;
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
+import com.firstone.greenjangteo.post.domain.comment.service.CommentService;
+import com.firstone.greenjangteo.utility.InputFormatValidator;
+import com.firstone.greenjangteo.utility.RoleValidator;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@RequestMapping("/comments")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    private static final String CREATE_COMMENT = "댓글 등록";
+    private static final String CREATE_COMMENT_DESCRIPTION = "회원 ID와 게시글 ID, 댓글 내용을 입력해 댓글을 등록할 수 있습니다.";
+    private static final String CREATE_COMMENT_FORM = "댓글 등록 양식";
+
+    @ApiOperation(value = CREATE_COMMENT, notes = CREATE_COMMENT_DESCRIPTION)
+    @PostMapping()
+    public ResponseEntity<CommentResponseDto> createComment
+            (@Valid @RequestBody @ApiParam(value = CREATE_COMMENT_FORM) CommentRequestDto commentRequestDto) {
+        InputFormatValidator.validateId(commentRequestDto.getPostId());
+        RoleValidator.checkAdminOrPrincipalAuthentication(commentRequestDto.getUserId());
+
+        Comment comment = commentService.createComment(commentRequestDto);
+
+        return buildResponse(CommentResponseDto.from(comment));
+    }
+
+    private ResponseEntity<CommentResponseDto> buildResponse(CommentResponseDto commentResponseDto) {
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{commentId}")
+                .buildAndExpand(commentResponseDto.getCommentId())
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(location);
+
+        return ResponseEntity.status(HttpStatus.CREATED).headers(headers).body(commentResponseDto);
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/dto/CommentRequestDto.java
@@ -1,0 +1,40 @@
+package com.firstone.greenjangteo.post.domain.comment.dto;
+
+import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+import static com.firstone.greenjangteo.post.controller.PostController.POST_ID;
+import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
+import static com.firstone.greenjangteo.web.ApiConstant.USER_ID_VALUE;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class CommentRequestDto {
+    private static final String CONTENT_VALUE = "댓글 내용";
+    private static final String CONTENT_EXAMPLE = "답변 드립니다.";
+    private static final String CONTENT_NO_VALUE_EXCEPTION_MESSAGE = "댓글 내용을 입력하세요.";
+
+    private static final String IMAGE_REQUEST_DTOS_VALUE = "댓글에 포함되는 이미지들";
+
+    @ApiModelProperty(value = USER_ID_VALUE, example = ID_EXAMPLE)
+    private String userId;
+
+    @ApiModelProperty(value = POST_ID, example = ID_EXAMPLE)
+    private String postId;
+
+    @ApiModelProperty(value = CONTENT_VALUE, example = CONTENT_EXAMPLE)
+    @NotBlank(message = CONTENT_NO_VALUE_EXCEPTION_MESSAGE)
+    private String content;
+
+    @ApiModelProperty(value = IMAGE_REQUEST_DTOS_VALUE)
+    private List<ImageRequestDto> imageRequestDtos;
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/dto/CommentResponseDto.java
@@ -1,0 +1,56 @@
+package com.firstone.greenjangteo.post.domain.comment.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
+import com.firstone.greenjangteo.post.domain.image.dto.ImageResponseDto;
+import com.firstone.greenjangteo.user.model.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentResponseDto {
+    private Long commentId;
+    private Long userId;
+    private String username;
+    private String content;
+    private List<ImageResponseDto> imageResponseDtos;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime createdAt;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime modifiedAt;
+
+    public static CommentResponseDto from(Comment comment) {
+        User user = comment.getUser();
+
+        return CommentResponseDto.builder()
+                .commentId(comment.getId())
+                .userId(user.getId())
+                .username(user.getUsername().getValue())
+                .content(comment.getContent())
+                .imageResponseDtos(
+                        comment.getImages() == null
+                                ? null
+                                : comment.getImages().stream().map(ImageResponseDto::from)
+                                .collect(Collectors.toList())
+                )
+                .createdAt(comment.getCreatedAt())
+                .modifiedAt(comment.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/model/entity/Comment.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/model/entity/Comment.java
@@ -1,0 +1,56 @@
+package com.firstone.greenjangteo.post.domain.comment.model.entity;
+
+import com.firstone.greenjangteo.audit.BaseEntity;
+import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
+import com.firstone.greenjangteo.post.model.entity.Post;
+import com.firstone.greenjangteo.user.model.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+import static javax.persistence.CascadeType.*;
+
+@Entity(name = "comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "comment")
+public class Comment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10_000)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @OneToMany(mappedBy = "comment", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.LAZY)
+    private List<Image> images;
+
+    @Builder
+    private Comment(Long id, String content, User user, Post post, List<Image> images) {
+        this.id = id;
+        this.content = content;
+        this.user = user;
+        this.post = post;
+        this.images = images;
+    }
+
+    public static Comment of(String content, User user, Post post) {
+        return Comment.builder()
+                .content(content)
+                .user(user)
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.firstone.greenjangteo.post.domain.comment.repository;
+
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
@@ -1,0 +1,8 @@
+package com.firstone.greenjangteo.post.domain.comment.service;
+
+import com.firstone.greenjangteo.post.domain.comment.dto.CommentRequestDto;
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
+
+public interface CommentService {
+    Comment createComment(CommentRequestDto commentRequestDto);
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
@@ -1,0 +1,45 @@
+package com.firstone.greenjangteo.post.domain.comment.service;
+
+import com.firstone.greenjangteo.post.domain.comment.dto.CommentRequestDto;
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
+import com.firstone.greenjangteo.post.domain.comment.repository.CommentRepository;
+import com.firstone.greenjangteo.post.domain.image.service.ImageService;
+import com.firstone.greenjangteo.post.model.entity.Post;
+import com.firstone.greenjangteo.post.service.PostService;
+import com.firstone.greenjangteo.user.model.entity.User;
+import com.firstone.greenjangteo.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CommentServiceImpl implements CommentService {
+    private final CommentRepository commentRepository;
+    private final UserService userService;
+    private final PostService postService;
+    private final ImageService imageService;
+
+    private final EntityManager entityManager;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, timeout = 20)
+    public Comment createComment(CommentRequestDto commentRequestDto) {
+        User user = userService.getUser(Long.parseLong(commentRequestDto.getUserId()));
+        Post post = postService.getPost(Long.parseLong(commentRequestDto.getPostId()));
+        Comment comment = commentRepository.save(Comment.of(commentRequestDto.getContent(), user, post));
+
+        if (commentRequestDto.getImageRequestDtos() != null) {
+            imageService.saveImages(comment, commentRequestDto.getImageRequestDtos());
+            entityManager.refresh(comment);
+        }
+
+        return comment;
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/image/model/entity/Image.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/image/model/entity/Image.java
@@ -2,6 +2,7 @@ package com.firstone.greenjangteo.post.domain.image.model.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.firstone.greenjangteo.audit.BaseEntity;
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.model.entity.Post;
 import lombok.AccessLevel;
@@ -31,11 +32,16 @@ public class Image extends BaseEntity {
     @JsonBackReference
     private Post post;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
     @Builder
-    private Image(String url, int positionInContent, Post post) {
+    private Image(String url, int positionInContent, Post post, Comment comment) {
         this.url = url;
         this.positionInContent = positionInContent;
         this.post = post;
+        this.comment = comment;
     }
 
     public static Image from(Post post, ImageRequestDto imageRequestDto) {
@@ -43,6 +49,14 @@ public class Image extends BaseEntity {
                 .url(imageRequestDto.getUrl())
                 .positionInContent(imageRequestDto.getPositionInContent())
                 .post(post)
+                .build();
+    }
+
+    public static Image from(Comment comment, ImageRequestDto imageRequestDto) {
+        return Image.builder()
+                .url(imageRequestDto.getUrl())
+                .positionInContent(imageRequestDto.getPositionInContent())
+                .comment(comment)
                 .build();
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/post/domain/image/service/ImageService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package com.firstone.greenjangteo.post.domain.image.service;
 
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
 import com.firstone.greenjangteo.post.domain.image.repository.ImageRepository;
@@ -65,6 +66,14 @@ public class ImageService {
 
         imageRepository.deleteAllInList(imagesToDelete);
         imageRepository.saveAll(imagesToSave);
+    }
+
+    public void saveImages(Comment comment, List<ImageRequestDto> imageRequestDtos) {
+        List<Image> images = imageRequestDtos.stream()
+                .map(imageRequestDto -> Image.from(comment, imageRequestDto))
+                .collect(Collectors.toList());
+
+        imageRepository.saveAll(images);
     }
 
     private void deleteAllPostImages(Long postId) {

--- a/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
+++ b/src/main/java/com/firstone/greenjangteo/post/model/entity/Post.java
@@ -2,6 +2,7 @@ package com.firstone.greenjangteo.post.model.entity;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.firstone.greenjangteo.audit.BaseEntity;
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
 import com.firstone.greenjangteo.post.dto.PostRequestDto;
 import com.firstone.greenjangteo.user.model.entity.User;
@@ -38,6 +39,9 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.LAZY)
     @JsonManagedReference
     private List<Image> images;
+
+    @OneToMany(mappedBy = "post", cascade = REMOVE, fetch = FetchType.LAZY)
+    private List<Comment> comments;
 
     @Builder
     private Post(Long id, String subject, String content, User user, List<Image> images) {

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostService.java
@@ -14,6 +14,8 @@ public interface PostService {
 
     Post getPost(Long postId, Long writerId);
 
+    Post getPost(Long postId);
+
     Post updatePost(Long postId, PostRequestDto postRequestDto);
 
     void deletePost(Long postId, Long userId);

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
@@ -77,11 +77,17 @@ public class PostServiceImpl implements PostService {
     @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 15)
     @Cacheable(key = GET_POST_KEY, condition = GET_KEY_CONDITION, unless = UNLESS_CONDITION, value = KEY_VALUE)
     public Post getPost(Long postId, Long writerId) {
-        Post post = postRepository.findByIdAndUserId(postId, writerId)
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException
                         (POST_NOT_FOUND_EXCEPTION + postId + POSTED_USER_ID_NOT_FOUND_EXCEPTION + writerId));
 
         return post;
+    }
+
+    @Override
+    public Post getPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException(POST_NOT_FOUND_EXCEPTION + postId));
     }
 
     @Override

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentControllerTest.java
@@ -1,0 +1,82 @@
+package com.firstone.greenjangteo.post.domain.comment.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.firstone.greenjangteo.post.domain.comment.dto.CommentRequestDto;
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
+import com.firstone.greenjangteo.post.domain.comment.service.CommentService;
+import com.firstone.greenjangteo.post.domain.comment.service.CommentTestObjectFactory;
+import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
+import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
+import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
+import com.firstone.greenjangteo.post.model.entity.Post;
+import com.firstone.greenjangteo.user.model.Username;
+import com.firstone.greenjangteo.user.model.entity.User;
+import com.firstone.greenjangteo.user.security.CustomAuthenticationEntryPoint;
+import com.firstone.greenjangteo.user.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static com.firstone.greenjangteo.order.testutil.OrderTestConstant.BUYER_ID;
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.CONTENT1;
+import static com.firstone.greenjangteo.user.testutil.UserTestConstant.USERNAME1;
+import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = CommentController.class)
+class CommentControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CommentService commentService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @DisplayName("등록된 게시글의 댓글을 등록할 수 있다.")
+    @Test
+    @WithMockUser(username = BUYER_ID, roles = {"BUYER"})
+    void createComment() throws Exception {
+        // given
+        User user = mock(User.class);
+        Post post = mock(Post.class);
+        List<ImageRequestDto> imageRequestDtos = ImageTestObjectFactory.createImageRequestDtos();
+
+        CommentRequestDto commentRequestDto
+                = CommentTestObjectFactory.createCommentRequestDto(BUYER_ID, ID_EXAMPLE, CONTENT1, imageRequestDtos);
+
+        List<Image> images = ImageTestObjectFactory.createImages();
+        Comment comment = CommentTestObjectFactory.createComment(ID_EXAMPLE, CONTENT1, user, post, images);
+        when(commentService.createComment(any(CommentRequestDto.class))).thenReturn(comment);
+        when(user.getUsername()).thenReturn(Username.of(USERNAME1));
+
+        // when, then
+        mockMvc.perform(post("/comments")
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(commentRequestDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+    }
+
+}

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,81 @@
+package com.firstone.greenjangteo.post.domain.comment.service;
+
+import com.firstone.greenjangteo.post.domain.comment.dto.CommentRequestDto;
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
+import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
+import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
+import com.firstone.greenjangteo.post.model.entity.Post;
+import com.firstone.greenjangteo.post.repository.PostRepository;
+import com.firstone.greenjangteo.post.service.PostService;
+import com.firstone.greenjangteo.post.utility.PostTestObjectFactory;
+import com.firstone.greenjangteo.user.model.entity.User;
+import com.firstone.greenjangteo.user.repository.UserRepository;
+import com.firstone.greenjangteo.user.testutil.UserTestObjectFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.firstone.greenjangteo.post.domain.image.testutil.ImageTestConstant.*;
+import static com.firstone.greenjangteo.post.utility.PostTestConstant.*;
+import static com.firstone.greenjangteo.user.model.Role.ROLE_BUYER;
+import static com.firstone.greenjangteo.user.testutil.UserTestConstant.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class CommentServiceTest {
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @DisplayName("게시글의 댓글을 등록할 수 있다.")
+    @Test
+    void createComment() {
+        // given
+        User user = UserTestObjectFactory.createUser(
+                EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.name())
+        );
+        userRepository.save(user);
+
+        Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
+        postRepository.save(post);
+
+        List<ImageRequestDto> imageRequestDtos = ImageTestObjectFactory.createImageRequestDtos();
+        CommentRequestDto commentRequestDto = CommentTestObjectFactory
+                .createCommentRequestDto(user.getId().toString(), post.getId().toString(), CONTENT2, imageRequestDtos);
+
+        // when
+        Comment comment = commentService.createComment(commentRequestDto);
+
+        // then
+        assertThat(comment.getContent()).isEqualTo(CONTENT2);
+        assertThat(comment.getPost()).isEqualTo(post);
+        assertThat(comment.getUser()).isEqualTo(user);
+        assertThat(comment.getImages()).hasSize(imageRequestDtos.size())
+                .extracting("url", "positionInContent")
+                .containsExactlyInAnyOrder(
+                        tuple(IMAGE_URL1, POSITION_IN_CONTENT),
+                        tuple(IMAGE_URL2, POSITION_IN_CONTENT + 1),
+                        tuple(IMAGE_URL3, POSITION_IN_CONTENT + 2)
+                );
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentTestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentTestObjectFactory.java
@@ -1,0 +1,39 @@
+package com.firstone.greenjangteo.post.domain.comment.service;
+
+import com.firstone.greenjangteo.post.domain.comment.dto.CommentRequestDto;
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
+import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
+import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
+import com.firstone.greenjangteo.post.model.entity.Post;
+import com.firstone.greenjangteo.user.model.entity.User;
+
+import java.util.List;
+
+public class CommentTestObjectFactory {
+    public static CommentRequestDto createCommentRequestDto
+            (String userId, String postId, String content, List<ImageRequestDto> imageRequestDtos) {
+        return CommentRequestDto.builder()
+                .userId(userId)
+                .postId(postId)
+                .content(content)
+                .imageRequestDtos(imageRequestDtos)
+                .build();
+    }
+
+    public static Comment createComment(String commentId, String content, User user, Post post, List<Image> images) {
+        return Comment.builder()
+                .id(Long.parseLong(commentId))
+                .content(content)
+                .user(user)
+                .post(post)
+                .images(images)
+                .build();
+    }
+
+    public static Comment createComment(String commentId, String content) {
+        return Comment.builder()
+                .id(Long.parseLong(commentId))
+                .content(content)
+                .build();
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/post/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/image/service/ImageServiceTest.java
@@ -1,5 +1,8 @@
 package com.firstone.greenjangteo.post.domain.image.service;
 
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
+import com.firstone.greenjangteo.post.domain.comment.repository.CommentRepository;
+import com.firstone.greenjangteo.post.domain.comment.service.CommentTestObjectFactory;
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
 import com.firstone.greenjangteo.post.domain.image.repository.ImageRepository;
@@ -19,6 +22,7 @@ import java.util.List;
 import static com.firstone.greenjangteo.post.domain.image.testutil.ImageTestConstant.*;
 import static com.firstone.greenjangteo.post.utility.PostTestConstant.CONTENT1;
 import static com.firstone.greenjangteo.post.utility.PostTestConstant.SUBJECT1;
+import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
@@ -35,9 +39,12 @@ class ImageServiceTest {
     @Autowired
     private PostRepository postRepository;
 
+    @Autowired
+    private CommentRepository commentRepository;
+
     @DisplayName("전송된 게시글 이미지의 목록을 저장할 수 있다.")
     @Test
-    void saveImages() {
+    void savePostImages() {
         // given
         Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
         postRepository.save(post);
@@ -56,6 +63,30 @@ class ImageServiceTest {
                         tuple(IMAGE_URL1, POSITION_IN_CONTENT, post),
                         tuple(IMAGE_URL2, POSITION_IN_CONTENT + 1, post),
                         tuple(IMAGE_URL3, POSITION_IN_CONTENT + 2, post)
+                );
+    }
+
+    @DisplayName("전송된 댓글 이미지의 목록을 저장할 수 있다.")
+    @Test
+    void saveCommentImages() {
+        // given
+        Comment comment = CommentTestObjectFactory.createComment(ID_EXAMPLE, CONTENT1);
+        commentRepository.save(comment);
+
+        List<ImageRequestDto> imageRequestDtos = ImageTestObjectFactory.createImageRequestDtos();
+
+        // when
+        imageService.saveImages(comment, imageRequestDtos);
+
+        List<Image> images = imageRepository.findAll();
+
+        // then
+        assertThat(images).hasSize(3)
+                .extracting("url", "positionInContent", "comment")
+                .containsExactlyInAnyOrder(
+                        tuple(IMAGE_URL1, POSITION_IN_CONTENT, comment),
+                        tuple(IMAGE_URL2, POSITION_IN_CONTENT + 1, comment),
+                        tuple(IMAGE_URL3, POSITION_IN_CONTENT + 2, comment)
                 );
     }
 }


### PR DESCRIPTION
## resolve #225

## 추가사항

### 프로덕션 코드
- 댓글 등록 요청
- 댓글 등록 요청 비즈니스 로직
- 게시글 ID를 통한 게시글 조회
- 댓글 데이터 저장
- 댓글에 포함된 이미지 목록 저장
- 201 status code 반환
- 비즈니스 로직의 로깅 AOP 추가
    - 댓글 등록
    - 이미지 목록 저장

### 테스트 코드
- 댓글 등록 요청, 201 status code 응답
- 댓글 등록 비즈니스 로직
- 게시글 ID를 통한 게시글 조회
- 이미지 목록 저장 비즈니스 로직