### PR TITLE
[#229] 게시글의 댓글 수 조회 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
+++ b/src/main/java/com/firstone/greenjangteo/post/controller/PostController.java
@@ -191,7 +191,8 @@ public class PostController {
         List<PostsResponseDto> postsResponseDtos = new ArrayList<>();
         for (Post post : posts) {
             View view = viewService.getView(post.getId());
-            PostsResponseDto postsResponseDto = PostsResponseDto.from(post, view.getViewCount());
+            int commentCount = commentService.getCommentCountForPost(post.getId());
+            PostsResponseDto postsResponseDto = PostsResponseDto.from(post, view.getViewCount(), commentCount);
             postsResponseDtos.add(postsResponseDto);
         }
 

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepository.java
@@ -4,7 +4,12 @@ import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByPostId(Long postId, Pageable pageable);
+
+    @Query("SELECT COUNT(c) FROM comment c WHERE c.post.id = :postId")
+    Long countByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
@@ -9,4 +9,6 @@ public interface CommentService {
     Comment createComment(CommentRequestDto commentRequestDto);
 
     Page<Comment> getComments(Pageable pageable, Long postId);
+
+    int getCommentCountForPost(Long postId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
@@ -51,4 +51,10 @@ public class CommentServiceImpl implements CommentService {
     public Page<Comment> getComments(Pageable pageable, Long postId) {
         return commentRepository.findByPostId(postId, pageable);
     }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 5)
+    public int getCommentCountForPost(Long postId) {
+        return commentRepository.countByPostId(postId).intValue();
+    }
 }

--- a/src/main/java/com/firstone/greenjangteo/post/dto/PostResponseDto.java
+++ b/src/main/java/com/firstone/greenjangteo/post/dto/PostResponseDto.java
@@ -27,6 +27,7 @@ public class PostResponseDto {
     private String subject;
     private String content;
     private int viewCount;
+    private int commentCount;
     private List<ImageResponseDto> imageResponseDtos;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
@@ -57,7 +58,7 @@ public class PostResponseDto {
                 .build();
     }
 
-    public static PostResponseDto from(Post post, int viewCount) {
+    public static PostResponseDto from(Post post, int viewCount, int commentCount) {
         User user = post.getUser();
 
         return PostResponseDto.builder()
@@ -67,6 +68,7 @@ public class PostResponseDto {
                 .subject(post.getSubject())
                 .content(post.getContent())
                 .viewCount(viewCount)
+                .commentCount(commentCount)
                 .imageResponseDtos(
                         post.getImages() == null
                                 ? null

--- a/src/main/java/com/firstone/greenjangteo/post/dto/PostsResponseDto.java
+++ b/src/main/java/com/firstone/greenjangteo/post/dto/PostsResponseDto.java
@@ -21,6 +21,7 @@ public class PostsResponseDto {
     private String username;
     private String subject;
     private int viewCount;
+    private int commentCount;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
@@ -30,12 +31,13 @@ public class PostsResponseDto {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime modifiedAt;
 
-    public static PostsResponseDto from(Post post, int viewCount) {
+    public static PostsResponseDto from(Post post, int viewCount, int commentCount) {
         return PostsResponseDto.builder()
                 .postId(post.getId())
                 .username(post.getUser().getUsername().getValue())
                 .subject(post.getSubject())
                 .viewCount(viewCount)
+                .commentCount(commentCount)
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
                 .build();

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepositoryTest.java
@@ -96,4 +96,26 @@ class CommentRepositoryTest {
                         tuple(IMAGE_URL3, POSITION_IN_CONTENT + 2)
                 );
     }
+
+    @DisplayName("게시글 ID를 통해 게시글의 댓글 수를 검색할 수 있다.")
+    @Test
+    void countByPostId() {
+        // given
+        Post post1 = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
+        Post post2 = PostTestObjectFactory.createPost(SUBJECT2, CONTENT2);
+        postRepository.saveAll(List.of(post1, post2));
+
+        Comment comment1 = CommentTestObjectFactory.createComment(CONTENT1, post1);
+        Comment comment2 = CommentTestObjectFactory.createComment(CONTENT2, post2);
+        Comment comment3 = CommentTestObjectFactory.createComment(CONTENT3, post2);
+        commentRepository.saveAll(List.of(comment1, comment2, comment3));
+
+        // when
+        Long commentCount1 = commentRepository.countByPostId(post1.getId());
+        Long commentCount2 = commentRepository.countByPostId(post2.getId());
+
+        // then
+        assertThat(commentCount1).isEqualTo(1L);
+        assertThat(commentCount2).isEqualTo(2L);
+    }
 }

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceTest.java
@@ -137,4 +137,26 @@ class CommentServiceTest {
                         tuple(IMAGE_URL3, POSITION_IN_CONTENT + 2)
                 );
     }
+
+    @DisplayName("게시글 ID를 통해 게시글의 댓글 수를 조회할 수 있다.")
+    @Test
+    void getCommentCountForPost() {
+        // given
+        Post post1 = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
+        Post post2 = PostTestObjectFactory.createPost(SUBJECT2, CONTENT2);
+        postRepository.saveAll(List.of(post1, post2));
+
+        Comment comment1 = CommentTestObjectFactory.createComment(CONTENT1, post1);
+        Comment comment2 = CommentTestObjectFactory.createComment(CONTENT2, post2);
+        Comment comment3 = CommentTestObjectFactory.createComment(CONTENT3, post2);
+        commentRepository.saveAll(List.of(comment1, comment2, comment3));
+
+        // when
+        int commentCount1 = commentService.getCommentCountForPost(post1.getId());
+        int commentCount2 = commentService.getCommentCountForPost(post2.getId());
+
+        // then
+        assertThat(commentCount1).isEqualTo(1);
+        assertThat(commentCount2).isEqualTo(2);
+    }
 }

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentTestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentTestObjectFactory.java
@@ -27,6 +27,13 @@ public class CommentTestObjectFactory {
                 .build();
     }
 
+    public static Comment createComment(String content, Post post) {
+        return Comment.builder()
+                .content(content)
+                .post(post)
+                .build();
+    }
+
     public static Comment createComment(String content, User user, Post post) {
         return Comment.builder()
                 .content(content)


### PR DESCRIPTION
## resolve #229

## 추가사항

### 프로덕션 코드
- 댓글 수 조회 요청
- 댓글 수 조회 비즈니스 로직
- 게시글 ID를 통한 댓글 수 조회

### 테스트 코드
- 댓글 수 조회 비즈니스 로직
- 게시글 ID를 통한 댓글 수 조회