### PR TITLE
[#231] 댓글 조회 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/exception/message/NotFoundExceptionMessage.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/exception/message/NotFoundExceptionMessage.java
@@ -1,0 +1,6 @@
+package com.firstone.greenjangteo.post.domain.comment.exception.message;
+
+public class NotFoundExceptionMessage {
+    public static final String COMMENT_NOT_FOUND_EXCEPTION = "해당하는 댓글을 찾을 수 없습니다. 댓글 ID: ";
+    public static final String COMMENTED_USER_ID_NOT_FOUND_EXCEPTION = ", 댓글 작성자 ID: ";
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepository.java
@@ -7,8 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByPostId(Long postId, Pageable pageable);
+
+    Optional<Comment> findByIdAndUserId(Long id, Long userId);
 
     @Query("SELECT COUNT(c) FROM comment c WHERE c.post.id = :postId")
     Long countByPostId(@Param("postId") Long postId);

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
@@ -10,5 +10,7 @@ public interface CommentService {
 
     Page<Comment> getComments(Pageable pageable, Long postId);
 
+    Comment getComment(Long commentId, Long writerId);
+
     int getCommentCountForPost(Long postId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
@@ -16,7 +16,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
 
+import static com.firstone.greenjangteo.post.domain.comment.exception.message.NotFoundExceptionMessage.COMMENTED_USER_ID_NOT_FOUND_EXCEPTION;
+import static com.firstone.greenjangteo.post.domain.comment.exception.message.NotFoundExceptionMessage.COMMENT_NOT_FOUND_EXCEPTION;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 import static org.springframework.transaction.annotation.Isolation.REPEATABLE_READ;
 
@@ -50,6 +53,13 @@ public class CommentServiceImpl implements CommentService {
     @Transactional(isolation = REPEATABLE_READ, readOnly = true, timeout = 15)
     public Page<Comment> getComments(Pageable pageable, Long postId) {
         return commentRepository.findByPostId(postId, pageable);
+    }
+
+    @Override
+    public Comment getComment(Long commentId, Long writerId) {
+        return commentRepository.findByIdAndUserId(commentId, writerId)
+                .orElseThrow(() -> new EntityNotFoundException
+                        (COMMENT_NOT_FOUND_EXCEPTION + commentId + COMMENTED_USER_ID_NOT_FOUND_EXCEPTION + writerId));
     }
 
     @Override

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepositoryTest.java
@@ -3,6 +3,7 @@ package com.firstone.greenjangteo.post.domain.comment.repository;
 import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
 import com.firstone.greenjangteo.post.domain.comment.service.CommentTestObjectFactory;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
+import com.firstone.greenjangteo.post.domain.image.repository.ImageRepository;
 import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
 import com.firstone.greenjangteo.post.model.entity.Post;
 import com.firstone.greenjangteo.post.repository.PostRepository;
@@ -42,6 +43,9 @@ class CommentRepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private ImageRepository imageRepository;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -89,6 +93,40 @@ class CommentRepositoryTest {
                         tuple(IMAGE_URL3, POSITION_IN_CONTENT + 2)
                 );
         assertThat(comments.get(1).getImages()).hasSize(3)
+                .extracting("url", "positionInContent")
+                .containsExactlyInAnyOrder(
+                        tuple(IMAGE_URL1, POSITION_IN_CONTENT),
+                        tuple(IMAGE_URL2, POSITION_IN_CONTENT + 1),
+                        tuple(IMAGE_URL3, POSITION_IN_CONTENT + 2)
+                );
+    }
+
+    @DisplayName("댓글 ID와 작성자 ID를 통해 댓글을 검색할 수 있다.")
+    @Test
+    void findByIdAndUserId() {
+        // given
+        Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
+        postRepository.save(post);
+
+        User user = UserTestObjectFactory.createUser(
+                EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.name())
+        );
+        userRepository.save(user);
+
+        List<Image> images = ImageTestObjectFactory.createImages();
+        imageRepository.saveAll(images);
+
+        Comment createdComment = CommentTestObjectFactory.createComment(CONTENT1, user, post, images);
+        commentRepository.save(createdComment);
+
+        // when
+        Comment foundComment = commentRepository.findByIdAndUserId(createdComment.getId(), user.getId()).get();
+
+        // then
+        assertThat(foundComment).isEqualTo(createdComment);
+        assertThat(foundComment.getPost()).isEqualTo(post);
+        assertThat(foundComment.getUser()).isEqualTo(user);
+        assertThat(foundComment.getImages()).hasSize(images.size())
                 .extracting("url", "positionInContent")
                 .containsExactlyInAnyOrder(
                         tuple(IMAGE_URL1, POSITION_IN_CONTENT),


### PR DESCRIPTION
## resolve #231

## 추가사항

### 프로덕션 코드
- 댓글 조회 비즈니스 로직
- 댓글 ID와 작성자 ID를 통해 댓글 조회
- 일치하지 않는 댓글 또는 작성자 ID를 통한 조회 시 예외 처리

### 테스트 코드
- 댓글 조회 비즈니스 로직
- 댓글 ID와 작성자 ID를 통해 댓글 조회
- 일치하지 않는 댓글 또는 작성자 ID를 통한 조회 시 예외 처리