### PR TITLE
[#233] 댓글 수정 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentController.java
@@ -41,6 +41,11 @@ public class CommentController {
     private static final String GET_ALL_COMMENTS_DESCRIPTION = "게시글 전체 댓글 목록을 조회할 수 있습니다." +
             "\n페이징 옵션을 선택할 수 있습니다.";
 
+    private static final String UPDATE_COMMENT = "댓글 수정";
+    private static final String UPDATE_COMMENT_DESCRIPTION = "댓글 ID와 회원 ID를 입력해 댓글을 수정할 수 있습니다.";
+    private static final String UPDATE_COMMENT_FORM = "댓글 수정 양식";
+    public static final String COMMENT_ID = "댓글 ID";
+    
     @ApiOperation(value = CREATE_COMMENT, notes = CREATE_COMMENT_DESCRIPTION)
     @PostMapping()
     public ResponseEntity<CommentResponseDto> createComment
@@ -76,6 +81,23 @@ public class CommentController {
                 = comments.stream().map(CommentResponseDto::from).collect(Collectors.toList());
 
         return ResponseEntity.status(HttpStatus.OK).body(commentResponseDtos);
+    }
+
+    @ApiOperation(value = UPDATE_COMMENT, notes = UPDATE_COMMENT_DESCRIPTION)
+    @PutMapping("{commentId}")
+    public ResponseEntity<CommentResponseDto> updateComment
+            (@PathVariable @ApiParam(value = COMMENT_ID, example = ID_EXAMPLE) String commentId,
+             @Valid @RequestBody @ApiParam(value = UPDATE_COMMENT_FORM) CommentRequestDto commentRequestDto) {
+        String userId = commentRequestDto.getUserId();
+
+        InputFormatValidator.validateId(commentId);
+        InputFormatValidator.validateId(userId);
+
+        RoleValidator.checkAdminOrPrincipalAuthentication(userId);
+
+        Comment comment = commentService.updateComment(Long.parseLong(commentId), commentRequestDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(CommentResponseDto.from(comment));
     }
 
     private ResponseEntity<CommentResponseDto> buildResponse(CommentResponseDto commentResponseDto) {

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/exception/message/InconsistentExceptionMessage.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/exception/message/InconsistentExceptionMessage.java
@@ -1,0 +1,8 @@
+package com.firstone.greenjangteo.post.domain.comment.exception.message;
+
+public class InconsistentExceptionMessage {
+    public static final String INCONSISTENT_COMMENT_EXCEPTION_POST_ID
+            = "해당 댓글은 전송된 게시글 ID의 댓글이 아닙니다. 게시글 ID: ";
+    public static final String INCONSISTENT_COMMENT_EXCEPTION_COMMENT_ID
+            = ", 댓글 ID: ";
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/exception/serious/InconsistentCommentException.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/exception/serious/InconsistentCommentException.java
@@ -1,0 +1,15 @@
+package com.firstone.greenjangteo.post.domain.comment.exception.serious;
+
+import com.firstone.greenjangteo.exception.AbstractSeriousException;
+import org.springframework.http.HttpStatus;
+
+public class InconsistentCommentException extends AbstractSeriousException {
+    public InconsistentCommentException(String message) {
+        super(message);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.CONFLICT.value();
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/model/entity/Comment.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/model/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.firstone.greenjangteo.post.domain.comment.model.entity;
 
 import com.firstone.greenjangteo.audit.BaseEntity;
+import com.firstone.greenjangteo.post.domain.comment.dto.CommentRequestDto;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
 import com.firstone.greenjangteo.post.model.entity.Post;
 import com.firstone.greenjangteo.user.model.entity.User;
@@ -51,6 +52,16 @@ public class Comment extends BaseEntity {
                 .content(content)
                 .user(user)
                 .post(post)
+                .build();
+    }
+
+    public Comment updateFrom(CommentRequestDto commentRequestDto) {
+        return Comment.builder()
+                .id(id)
+                .content(commentRequestDto.getContent())
+                .user(user)
+                .post(post)
+                .images(images)
                 .build();
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
@@ -12,5 +12,7 @@ public interface CommentService {
 
     Comment getComment(Long commentId, Long writerId);
 
+    Comment updateComment(Long commentId, CommentRequestDto commentRequestDto);
+
     int getCommentCountForPost(Long postId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/image/repository/ImageRepository.java
@@ -11,9 +11,15 @@ import java.util.List;
 public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findAllByPostIdOrderByIdAsc(Long postId);
 
+    List<Image> findAllByCommentIdOrderByIdAsc(Long commentId);
+
     @Modifying
     @Query("DELETE FROM image i WHERE i.post.id = :postId")
     void deleteByPostId(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("DELETE FROM image i WHERE i.comment.id = :commentId")
+    void deleteByCommentId(@Param("commentId") Long commentId);
 
     @Modifying
     @Query("DELETE FROM image i WHERE i IN :images")

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentControllerTest.java
@@ -35,11 +35,11 @@ import static com.firstone.greenjangteo.user.testutil.UserTestConstant.USERNAME1
 import static com.firstone.greenjangteo.utility.PagingConstant.*;
 import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -113,6 +113,31 @@ class CommentControllerTest {
                         .param("page", ZERO)
                         .param("size", FIVE)
                         .param("sort", ORDER_BY_CREATED_AT_DESCENDING))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("댓글 ID를 전송해 댓글을 수정할 수 있다.")
+    @Test
+    @WithMockUser(username = BUYER_ID, roles = {"BUYER"})
+    void updateComment() throws Exception {
+        // given
+        User user = mock(User.class);
+        Post post = mock(Post.class);
+        Comment comment = CommentTestObjectFactory.createComment(ID_EXAMPLE, CONTENT1, user, post);
+
+        List<ImageRequestDto> imageRequestDtos = ImageTestObjectFactory.createImageRequestDtos();
+        CommentRequestDto commentRequestDto
+                = CommentTestObjectFactory.createCommentRequestDto(BUYER_ID, ID_EXAMPLE, CONTENT2, imageRequestDtos);
+
+        when(commentService.updateComment(anyLong(), any(CommentRequestDto.class))).thenReturn(comment);
+        when(user.getUsername()).thenReturn(Username.of(USERNAME1));
+
+        // when, then
+        mockMvc.perform(put("/comments/{commentId}", comment.getId())
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(commentRequestDto))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentTestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentTestObjectFactory.java
@@ -20,9 +20,8 @@ public class CommentTestObjectFactory {
                 .build();
     }
 
-    public static Comment createComment(String commentId, String content) {
+    public static Comment createComment(String content) {
         return Comment.builder()
-                .id(Long.parseLong(commentId))
                 .content(content)
                 .build();
     }
@@ -48,6 +47,15 @@ public class CommentTestObjectFactory {
                 .user(user)
                 .post(post)
                 .images(images)
+                .build();
+    }
+
+    public static Comment createComment(String commentId, String content, User user, Post post) {
+        return Comment.builder()
+                .id(Long.parseLong(commentId))
+                .content(content)
+                .user(user)
+                .post(post)
                 .build();
     }
 

--- a/src/test/java/com/firstone/greenjangteo/post/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/image/service/ImageServiceTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import static com.firstone.greenjangteo.post.domain.image.testutil.ImageTestConstant.*;
 import static com.firstone.greenjangteo.post.utility.PostTestConstant.CONTENT1;
 import static com.firstone.greenjangteo.post.utility.PostTestConstant.SUBJECT1;
-import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
@@ -66,11 +65,37 @@ class ImageServiceTest {
                 );
     }
 
+    @DisplayName("전송된 게시글 이미지의 목록을 수정할 수 있다.")
+    @Test
+    void updatePostImages() {
+        // given
+        Post post = PostTestObjectFactory.createPost(SUBJECT1, CONTENT1);
+        postRepository.save(post);
+
+        List<Image> createdImages = ImageTestObjectFactory.createImages(post);
+        imageRepository.saveAll(createdImages);
+
+        List<ImageRequestDto> imageRequestDtos = ImageTestObjectFactory.createImageUpdateRequestDtos();
+
+        // when
+        imageService.updateImages(post, imageRequestDtos);
+        List<Image> updatedImages = imageRepository.findAll();
+
+        // then
+        assertThat(updatedImages).hasSize(3)
+                .extracting("url", "positionInContent", "post")
+                .containsExactlyInAnyOrder(
+                        tuple(IMAGE_URL3, POSITION_IN_CONTENT, post),
+                        tuple(IMAGE_URL2, POSITION_IN_CONTENT + 2, post),
+                        tuple(IMAGE_URL1, POSITION_IN_CONTENT + 3, post)
+                );
+    }
+
     @DisplayName("전송된 댓글 이미지의 목록을 저장할 수 있다.")
     @Test
     void saveCommentImages() {
         // given
-        Comment comment = CommentTestObjectFactory.createComment(ID_EXAMPLE, CONTENT1);
+        Comment comment = CommentTestObjectFactory.createComment(CONTENT1);
         commentRepository.save(comment);
 
         List<ImageRequestDto> imageRequestDtos = ImageTestObjectFactory.createImageRequestDtos();
@@ -87,6 +112,32 @@ class ImageServiceTest {
                         tuple(IMAGE_URL1, POSITION_IN_CONTENT, comment),
                         tuple(IMAGE_URL2, POSITION_IN_CONTENT + 1, comment),
                         tuple(IMAGE_URL3, POSITION_IN_CONTENT + 2, comment)
+                );
+    }
+
+    @DisplayName("전송된 댓글 이미지의 목록을 수정할 수 있다.")
+    @Test
+    void updateCommentImages() {
+        // given
+        Comment comment = CommentTestObjectFactory.createComment(CONTENT1);
+        commentRepository.save(comment);
+
+        List<Image> createdImages = ImageTestObjectFactory.createImages(comment);
+        imageRepository.saveAll(createdImages);
+
+        List<ImageRequestDto> imageRequestDtos = ImageTestObjectFactory.createImageUpdateRequestDtos();
+
+        // when
+        imageService.updateImages(comment, imageRequestDtos);
+        List<Image> updatedImages = imageRepository.findAll();
+
+        // then
+        assertThat(updatedImages).hasSize(3)
+                .extracting("url", "positionInContent", "comment")
+                .containsExactlyInAnyOrder(
+                        tuple(IMAGE_URL3, POSITION_IN_CONTENT, comment),
+                        tuple(IMAGE_URL2, POSITION_IN_CONTENT + 2, comment),
+                        tuple(IMAGE_URL1, POSITION_IN_CONTENT + 3, comment)
                 );
     }
 }

--- a/src/test/java/com/firstone/greenjangteo/post/domain/image/testutil/ImageTestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/image/testutil/ImageTestObjectFactory.java
@@ -1,5 +1,6 @@
 package com.firstone.greenjangteo.post.domain.image.testutil;
 
+import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
 import com.firstone.greenjangteo.post.model.entity.Post;
@@ -29,16 +30,6 @@ public class ImageTestObjectFactory {
         return List.of(imageRequestDto1, imageRequestDto2, imageRequestDto3);
     }
 
-    public static List<Image> createImages(Post post) {
-        int position = POSITION_IN_CONTENT;
-
-        Image image1 = createImage(IMAGE_URL1, position++, post);
-        Image image2 = createImage(IMAGE_URL2, position++, post);
-        Image image3 = createImage(IMAGE_URL3, position, post);
-
-        return List.of(image1, image2, image3);
-    }
-
     public static List<Image> createImages() {
         int position = POSITION_IN_CONTENT;
 
@@ -49,8 +40,35 @@ public class ImageTestObjectFactory {
         return List.of(image1, image2, image3);
     }
 
+    public static List<Image> createImages(Post post) {
+        int position = POSITION_IN_CONTENT;
+
+        Image image1 = createImage(IMAGE_URL1, position++, post);
+        Image image2 = createImage(IMAGE_URL2, position++, post);
+        Image image3 = createImage(IMAGE_URL3, position, post);
+
+        return List.of(image1, image2, image3);
+    }
+
+    public static List<Image> createImages(Comment comment) {
+        int position = POSITION_IN_CONTENT;
+
+        Image image1 = createImage(IMAGE_URL1, position++, comment);
+        Image image2 = createImage(IMAGE_URL2, position++, comment);
+        Image image3 = createImage(IMAGE_URL3, position, comment);
+
+        return List.of(image1, image2, image3);
+    }
+
     private static ImageRequestDto createImageRequestDto(String imageUrl, int position) {
         return ImageRequestDto.builder()
+                .url(imageUrl)
+                .positionInContent(position)
+                .build();
+    }
+
+    private static Image createImage(String imageUrl, int position) {
+        return Image.builder()
                 .url(imageUrl)
                 .positionInContent(position)
                 .build();
@@ -64,10 +82,11 @@ public class ImageTestObjectFactory {
                 .build();
     }
 
-    private static Image createImage(String imageUrl, int position) {
+    private static Image createImage(String imageUrl, int position, Comment comment) {
         return Image.builder()
                 .url(imageUrl)
                 .positionInContent(position)
+                .comment(comment)
                 .build();
     }
 }


### PR DESCRIPTION
## resolve #233

## 추가사항

### 프로덕션 코드
- 댓글 수정 요청
- 댓글 수정 비즈니스 로직
- 수정하려는 댓글의 게시글 ID가 일치하지 않는 경우에 대한 예외 처리
- 이미지 수정 비즈니스 로직
- 댓글 ID를 통한 이미지 데이터 ID 오름차순 검색
- 댓글 ID를 통한 이미지 데이터 삭제
- 이미지 엔티티 목록을 통한 이미지 데이터 삭제
- 200 status code 반환

### 테스트 코드
- 댓글 수정 요청, 200 status code 응답
- 댓글 수정 비즈니스 로직
- 수정하려는 댓글 또는 작성자의 ID가 잘못된 경우에 대한 예외 처리
- 수정하려는 댓글의 게시글 ID가 일치하지 않는 경우에 대한 예외 처리
- 이미지 수정 비즈니스 로직
- 댓글 ID를 통한 이미지 데이터 ID 오름차순 검색
- 댓글 ID를 통한 이미지 데이터 삭제
- 이미지 엔티티 목록을 통한 이미지 데이터 삭제