### PR TITLE
[#235] 댓글 삭제 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentController.java
@@ -4,6 +4,8 @@ import com.firstone.greenjangteo.post.domain.comment.dto.CommentRequestDto;
 import com.firstone.greenjangteo.post.domain.comment.dto.CommentResponseDto;
 import com.firstone.greenjangteo.post.domain.comment.model.entity.Comment;
 import com.firstone.greenjangteo.post.domain.comment.service.CommentService;
+import com.firstone.greenjangteo.post.dto.PostResponseDto;
+import com.firstone.greenjangteo.user.dto.request.UserIdRequestDto;
 import com.firstone.greenjangteo.utility.FormatConverter;
 import com.firstone.greenjangteo.utility.InputFormatValidator;
 import com.firstone.greenjangteo.utility.RoleValidator;
@@ -26,6 +28,7 @@ import java.util.stream.Collectors;
 import static com.firstone.greenjangteo.post.controller.PostController.POST_ID;
 import static com.firstone.greenjangteo.utility.PagingConstant.*;
 import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
+import static com.firstone.greenjangteo.web.ApiConstant.USER_ID_VALUE;
 
 @RestController
 @RequestMapping("/comments")
@@ -45,7 +48,10 @@ public class CommentController {
     private static final String UPDATE_COMMENT_DESCRIPTION = "댓글 ID와 회원 ID를 입력해 댓글을 수정할 수 있습니다.";
     private static final String UPDATE_COMMENT_FORM = "댓글 수정 양식";
     public static final String COMMENT_ID = "댓글 ID";
-    
+
+    private static final String DELETE_COMMENT = "댓글 삭제";
+    private static final String DELETE_COMMENT_DESCRIPTION = "댓글 ID와 회원 ID를 입력해 댓글을 삭제할 수 있습니다.";
+
     @ApiOperation(value = CREATE_COMMENT, notes = CREATE_COMMENT_DESCRIPTION)
     @PostMapping()
     public ResponseEntity<CommentResponseDto> createComment
@@ -98,6 +104,22 @@ public class CommentController {
         Comment comment = commentService.updateComment(Long.parseLong(commentId), commentRequestDto);
 
         return ResponseEntity.status(HttpStatus.OK).body(CommentResponseDto.from(comment));
+    }
+
+    @ApiOperation(value = DELETE_COMMENT, notes = DELETE_COMMENT_DESCRIPTION)
+    @DeleteMapping("{commentId}")
+    public ResponseEntity<PostResponseDto> deleteComment
+            (@PathVariable @ApiParam(value = COMMENT_ID, example = ID_EXAMPLE) String commentId,
+             @RequestBody @ApiParam(value = USER_ID_VALUE) UserIdRequestDto userIdRequestDto) {
+        String userId = userIdRequestDto.getUserId();
+        InputFormatValidator.validateId(commentId);
+        InputFormatValidator.validateId(userId);
+
+        RoleValidator.checkAdminOrPrincipalAuthentication(userId);
+
+        commentService.deleteComment(Long.parseLong(commentId), Long.parseLong(userId));
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     private ResponseEntity<CommentResponseDto> buildResponse(CommentResponseDto commentResponseDto) {

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepository.java
@@ -14,6 +14,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Optional<Comment> findByIdAndUserId(Long id, Long userId);
 
+    boolean existsByIdAndUserId(Long commentId, Long userId);
+
     @Query("SELECT COUNT(c) FROM comment c WHERE c.post.id = :postId")
     Long countByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentService.java
@@ -14,5 +14,7 @@ public interface CommentService {
 
     Comment updateComment(Long commentId, CommentRequestDto commentRequestDto);
 
+    void deleteComment(Long commentId, Long userId);
+
     int getCommentCountForPost(Long postId);
 }

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
@@ -23,6 +23,7 @@ import static com.firstone.greenjangteo.post.domain.comment.exception.message.In
 import static com.firstone.greenjangteo.post.domain.comment.exception.message.InconsistentExceptionMessage.INCONSISTENT_COMMENT_EXCEPTION_POST_ID;
 import static com.firstone.greenjangteo.post.domain.comment.exception.message.NotFoundExceptionMessage.COMMENTED_USER_ID_NOT_FOUND_EXCEPTION;
 import static com.firstone.greenjangteo.post.domain.comment.exception.message.NotFoundExceptionMessage.COMMENT_NOT_FOUND_EXCEPTION;
+import static com.firstone.greenjangteo.post.exception.message.NotFoundExceptionMessage.POSTED_USER_ID_NOT_FOUND_EXCEPTION;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 import static org.springframework.transaction.annotation.Isolation.REPEATABLE_READ;
 
@@ -79,6 +80,19 @@ public class CommentServiceImpl implements CommentService {
         entityManager.refresh(updatedComment);
 
         return updatedComment;
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, timeout = 10)
+    public void deleteComment(Long commentId, Long userId) {
+        if (commentRepository.existsByIdAndUserId(commentId, userId)) {
+            commentRepository.deleteById(commentId);
+            return;
+        }
+
+        throw new EntityNotFoundException(
+                COMMENT_NOT_FOUND_EXCEPTION + commentId + COMMENTED_USER_ID_NOT_FOUND_EXCEPTION + userId
+        );
     }
 
     @Override

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/controller/CommentControllerTest.java
@@ -9,6 +9,7 @@ import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.domain.image.model.entity.Image;
 import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
 import com.firstone.greenjangteo.post.model.entity.Post;
+import com.firstone.greenjangteo.user.dto.request.UserIdRequestDto;
 import com.firstone.greenjangteo.user.model.Username;
 import com.firstone.greenjangteo.user.model.entity.User;
 import com.firstone.greenjangteo.user.security.CustomAuthenticationEntryPoint;
@@ -36,8 +37,7 @@ import static com.firstone.greenjangteo.utility.PagingConstant.*;
 import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -140,5 +140,22 @@ class CommentControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk());
+    }
+
+    @DisplayName("댓글 ID와 회원 ID를 전송해 댓글을 삭제할 수 있다.")
+    @Test
+    @WithMockUser(username = BUYER_ID, roles = {"BUYER"})
+    void deleteComment() throws Exception {
+        // given
+        doNothing().when(commentService).deleteComment(anyLong(), anyLong());
+        UserIdRequestDto userIdRequestDto = new UserIdRequestDto(BUYER_ID);
+
+        // when, then
+        mockMvc.perform(delete("/comments/{commentId}", BUYER_ID)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(userIdRequestDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/repository/CommentRepositoryTest.java
@@ -156,4 +156,32 @@ class CommentRepositoryTest {
         assertThat(commentCount1).isEqualTo(1L);
         assertThat(commentCount2).isEqualTo(2L);
     }
+
+    @DisplayName("댓글 ID와 회원 ID를 통해 댓글의 존재 여부를 확인할 수 있다.")
+    @Test
+    void existsByIdAndUserId() {
+        // given
+        User user = UserTestObjectFactory.createUser(
+                EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.name())
+        );
+        userRepository.save(user);
+
+        Comment comment1 = CommentTestObjectFactory.createComment(CONTENT1, user);
+        Comment comment2 = CommentTestObjectFactory.createComment(CONTENT2);
+        Comment comment3 = CommentTestObjectFactory.createComment(CONTENT3, user);
+
+        commentRepository.saveAll(List.of(comment1, comment2, comment3));
+        commentRepository.delete(comment1);
+
+        // when
+        boolean result1 = commentRepository.existsByIdAndUserId(comment1.getId(), user.getId());
+        boolean result2 = commentRepository.existsByIdAndUserId(comment2.getId(), user.getId());
+        boolean result3 = commentRepository.existsByIdAndUserId(comment3.getId(), user.getId());
+
+
+        // then
+        assertThat(result1).isFalse();
+        assertThat(result2).isFalse();
+        assertThat(result3).isTrue();
+    }
 }

--- a/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentTestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/post/domain/comment/service/CommentTestObjectFactory.java
@@ -26,6 +26,13 @@ public class CommentTestObjectFactory {
                 .build();
     }
 
+    public static Comment createComment(String content, User user) {
+        return Comment.builder()
+                .content(content)
+                .user(user)
+                .build();
+    }
+
     public static Comment createComment(String content, Post post) {
         return Comment.builder()
                 .content(content)


### PR DESCRIPTION
## resolve #235

## 추가사항

### 프로덕션 코드
- 댓글 삭제 요청
- 댓글 삭제 비즈니스 로직
- 댓글 ID와 회원 ID를 통해 댓글 존재 여부 확인
- 댓글 ID 또는 회원 ID가 일치하지 않는 경우 예외 처리
- 204 status code 반환

### 테스트 코드
- 댓글 삭제 요청, 204 status code 응답
- 댓글 삭제 비즈니스 로직
- 댓글 ID와 회원 ID를 통해 댓글 존재 여부 확인
- 댓글 ID 또는 회원 ID가 일치하지 않는 경우 예외 처리