### PR TITLE
[#239] 적립금 추가 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/reserve/aop/ReserveLoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/aop/ReserveLoggingAspect.java
@@ -1,0 +1,53 @@
+package com.firstone.greenjangteo.reserve.aop;
+
+import com.firstone.greenjangteo.reserve.dto.request.AddReserveRequestDto;
+import com.firstone.greenjangteo.utility.MemoryUtil;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+import static com.firstone.greenjangteo.aop.LogConstant.PERFORMANCE_MEASUREMENT;
+
+@Component
+@Aspect
+public class ReserveLoggingAspect {
+    private static final Logger log = LoggerFactory.getLogger(ReserveLoggingAspect.class);
+
+    private static final String ADD_RESERVE_POINTCUT
+            = "execution(* com.firstone.greenjangteo.user.domain.token.service.*.*(..)) && args(addReserveRequestDto)";
+    private static final String ADD_RESERVE_START
+            = "Beginning to '{}.{}' task by userId: '{}', addedReserve: '{}'";
+    private static final String ADD_RESERVE_END
+            = "'{}.{}' task was executed successfully by userId: '{}', addedReserve: '{}', ";
+
+    @Around(ADD_RESERVE_POINTCUT)
+    public Object logAroundForAddReserveRequestDto(ProceedingJoinPoint joinPoint, AddReserveRequestDto addReserveRequestDto)
+            throws Throwable {
+
+        log.info(ADD_RESERVE_START,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(),
+                addReserveRequestDto.getUserId(), addReserveRequestDto.getAddedReserve());
+
+        long beforeMemory = MemoryUtil.usedMemory();
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        Object process = joinPoint.proceed();
+
+        stopWatch.stop();
+        long memoryUsage = MemoryUtil.usedMemory() - beforeMemory;
+
+        log.info(ADD_RESERVE_END + PERFORMANCE_MEASUREMENT,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(),
+                addReserveRequestDto.getUserId(), addReserveRequestDto.getAddedReserve(),
+                stopWatch.getTotalTimeMillis(), memoryUsage);
+
+        return process;
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/reserve/controller/ReserveController.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/controller/ReserveController.java
@@ -1,0 +1,36 @@
+package com.firstone.greenjangteo.reserve.controller;
+
+import com.firstone.greenjangteo.post.dto.PostResponseDto;
+import com.firstone.greenjangteo.reserve.dto.request.AddReserveRequestDto;
+import com.firstone.greenjangteo.reserve.service.ReserveService;
+import com.firstone.greenjangteo.utility.InputFormatValidator;
+import com.firstone.greenjangteo.utility.RoleValidator;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reserves")
+@RequiredArgsConstructor
+public class ReserveController {
+    private final ReserveService reserveService;
+
+    private static final String ADD_RESERVE = "적립금 추가";
+    private static final String ADD_RESERVE_DESCRIPTION = "회원 ID와 적립 예정 금액을 입력해 적립금을 추가할 수 있습니다.";
+
+    @ApiOperation(value = ADD_RESERVE, notes = ADD_RESERVE_DESCRIPTION)
+    @PostMapping("/add")
+    public ResponseEntity<PostResponseDto> addReserve(@RequestBody AddReserveRequestDto addReserveRequestDto) {
+        InputFormatValidator.validateId(addReserveRequestDto.getUserId());
+        RoleValidator.checkAdminAuthentication();
+
+        reserveService.addReserve(addReserveRequestDto);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/reserve/dto/request/AddReserveRequestDto.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/dto/request/AddReserveRequestDto.java
@@ -1,0 +1,23 @@
+package com.firstone.greenjangteo.reserve.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
+import static com.firstone.greenjangteo.web.ApiConstant.USER_ID_VALUE;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AddReserveRequestDto {
+    private static final String USED_RESERVE_VALUE = "추가할 적립금";
+    static final String USED_RESERVE_EXAMPLE = "2000";
+
+    @ApiModelProperty(value = USER_ID_VALUE, example = ID_EXAMPLE)
+    private String userId;
+
+    @ApiModelProperty(value = USED_RESERVE_VALUE, example = USED_RESERVE_EXAMPLE)
+    private int addedReserve;
+}

--- a/src/main/java/com/firstone/greenjangteo/reserve/exception/message/InvalidExceptionMessage.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/exception/message/InvalidExceptionMessage.java
@@ -1,0 +1,6 @@
+package com.firstone.greenjangteo.reserve.exception.message;
+
+public class InvalidExceptionMessage {
+    public static final String INVALID_UPDATING_RESERVE_EXCEPTION
+            = "적립하거나 사용할 적립금 액수는 0 또는 양의 정수여야 합니다. 전송된 적립금 액수: ";
+}

--- a/src/main/java/com/firstone/greenjangteo/reserve/exception/message/NotFoundExceptionMessage.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/exception/message/NotFoundExceptionMessage.java
@@ -1,0 +1,5 @@
+package com.firstone.greenjangteo.reserve.exception.message;
+
+public class NotFoundExceptionMessage {
+    public static final String RESERVE_NOT_FOUND_EXCEPTION = "해당 회원의 적립금이 존재하지 않습니다. 회원 ID: ";
+}

--- a/src/main/java/com/firstone/greenjangteo/reserve/model/CurrentReserve.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/model/CurrentReserve.java
@@ -1,0 +1,58 @@
+package com.firstone.greenjangteo.reserve.model;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.Objects;
+
+import static com.firstone.greenjangteo.reserve.exception.message.InvalidExceptionMessage.INVALID_UPDATING_RESERVE_EXCEPTION;
+
+public class CurrentReserve {
+    private final int currentReserve;
+
+    public CurrentReserve(int currentReserve) {
+        this.currentReserve = currentReserve;
+    }
+
+    public static CurrentReserve addReserve(CurrentReserve currentReserve, int addedReserve) {
+        validateUpdatingReserve(addedReserve);
+        int newCurrentReserve = currentReserve.getValue() + addedReserve;
+
+        return new CurrentReserve(newCurrentReserve);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CurrentReserve that = (CurrentReserve) o;
+        return currentReserve == that.currentReserve;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currentReserve);
+    }
+
+    public int getValue() {
+        return currentReserve;
+    }
+
+    private static void validateUpdatingReserve(int updatingReserve) {
+        if (updatingReserve < 0) {
+            throw new IllegalArgumentException(INVALID_UPDATING_RESERVE_EXCEPTION + updatingReserve);
+        }
+    }
+
+    @Converter
+    public static class CurrentReserveConverter implements AttributeConverter<CurrentReserve, Integer> {
+        @Override
+        public Integer convertToDatabaseColumn(CurrentReserve currentReserve) {
+            return currentReserve == null ? null : currentReserve.currentReserve;
+        }
+
+        @Override
+        public CurrentReserve convertToEntityAttribute(Integer currentReserve) {
+            return currentReserve == null ? null : new CurrentReserve(currentReserve);
+        }
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/reserve/model/entity/ReserveHistory.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/model/entity/ReserveHistory.java
@@ -1,0 +1,63 @@
+package com.firstone.greenjangteo.reserve.model.entity;
+
+import com.firstone.greenjangteo.audit.BaseEntity;
+import com.firstone.greenjangteo.reserve.dto.request.AddReserveRequestDto;
+import com.firstone.greenjangteo.reserve.model.CurrentReserve;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Entity(name = "reserve_history")
+@Table(name = "reserve_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReserveHistory extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private Long orderId;
+    private int addedReserve;
+    private int usedReserve;
+
+    @Convert(converter = CurrentReserve.CurrentReserveConverter.class)
+    private CurrentReserve currentReserve;
+
+    @Builder
+    private ReserveHistory(Long userId, Long orderId, int addedReserve, int usedReserve, CurrentReserve currentReserve) {
+        this.userId = userId;
+        this.orderId = orderId;
+        this.addedReserve = addedReserve;
+        this.usedReserve = usedReserve;
+        this.currentReserve = currentReserve;
+    }
+
+    public static ReserveHistory from(AddReserveRequestDto addReserveRequestDto, CurrentReserve currentReserve) {
+        Long userId = Long.parseLong(addReserveRequestDto.getUserId());
+        int addedReserve = addReserveRequestDto.getAddedReserve();
+
+        return ReserveHistory.builder()
+                .userId(userId)
+                .addedReserve(addedReserve)
+                .currentReserve(CurrentReserve.addReserve(currentReserve, addedReserve))
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReserveHistory that = (ReserveHistory) o;
+        return addedReserve == that.addedReserve && usedReserve == that.usedReserve && Objects.equals(id, that.id) && Objects.equals(userId, that.userId) && Objects.equals(orderId, that.orderId) && Objects.equals(currentReserve, that.currentReserve);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, userId, orderId, addedReserve, usedReserve, currentReserve);
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/reserve/repository/ReserveHistoryRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/repository/ReserveHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.firstone.greenjangteo.reserve.repository;
+
+import com.firstone.greenjangteo.reserve.model.entity.ReserveHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReserveHistoryRepository extends JpaRepository<ReserveHistory, Long> {
+    Optional<ReserveHistory> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/firstone/greenjangteo/reserve/service/ReserveService.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/service/ReserveService.java
@@ -1,0 +1,7 @@
+package com.firstone.greenjangteo.reserve.service;
+
+import com.firstone.greenjangteo.reserve.dto.request.AddReserveRequestDto;
+
+public interface ReserveService {
+    void addReserve(AddReserveRequestDto addReserveRequestDto);
+}

--- a/src/main/java/com/firstone/greenjangteo/reserve/service/ReserveServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/reserve/service/ReserveServiceImpl.java
@@ -1,0 +1,38 @@
+package com.firstone.greenjangteo.reserve.service;
+
+import com.firstone.greenjangteo.reserve.dto.request.AddReserveRequestDto;
+import com.firstone.greenjangteo.reserve.model.CurrentReserve;
+import com.firstone.greenjangteo.reserve.model.entity.ReserveHistory;
+import com.firstone.greenjangteo.reserve.repository.ReserveHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityNotFoundException;
+
+import static com.firstone.greenjangteo.reserve.exception.message.NotFoundExceptionMessage.RESERVE_NOT_FOUND_EXCEPTION;
+
+@Service
+@RequiredArgsConstructor
+public class ReserveServiceImpl implements ReserveService {
+    private final ReserveHistoryRepository reserveHistoryRepository;
+
+    public void addReserve(AddReserveRequestDto addReserveRequestDto) {
+        Long userId = Long.parseLong(addReserveRequestDto.getUserId());
+        ReserveHistory newReserveHistory;
+
+        try {
+            ReserveHistory reserveHistory = getCurrentReserve(userId);
+            newReserveHistory
+                    = ReserveHistory.from(addReserveRequestDto, reserveHistory.getCurrentReserve());
+        } catch (EntityNotFoundException e) {
+            newReserveHistory = ReserveHistory.from(addReserveRequestDto, new CurrentReserve(0));
+        }
+
+        reserveHistoryRepository.save(newReserveHistory);
+    }
+
+    private ReserveHistory getCurrentReserve(Long userId) {
+        return reserveHistoryRepository.findFirstByUserIdOrderByCreatedAtDesc(userId)
+                .orElseThrow(() -> new EntityNotFoundException(RESERVE_NOT_FOUND_EXCEPTION + userId));
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/reserve/controller/ReserveControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/reserve/controller/ReserveControllerTest.java
@@ -1,0 +1,61 @@
+package com.firstone.greenjangteo.reserve.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.firstone.greenjangteo.reserve.dto.request.AddReserveRequestDto;
+import com.firstone.greenjangteo.reserve.service.ReserveService;
+import com.firstone.greenjangteo.reserve.testutil.ReserveTestObjectFactory;
+import com.firstone.greenjangteo.user.security.CustomAuthenticationEntryPoint;
+import com.firstone.greenjangteo.user.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.firstone.greenjangteo.reserve.testutil.ReserveTestConstant.RESERVE1;
+import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = ReserveController.class)
+class ReserveControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ReserveService reserveService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @DisplayName("회원 ID와 추가할 적립금을 전송해 적립금을 추가할 수 있다.")
+    @Test
+    @WithMockUser(username = ID_EXAMPLE, roles = {"ADMIN"})
+    void addReserve() throws Exception {
+        // given
+        AddReserveRequestDto addReserveRequestDto
+                = ReserveTestObjectFactory.createAddReserveRequestDto(ID_EXAMPLE, RESERVE1);
+
+        doNothing().when(reserveService).addReserve(addReserveRequestDto);
+
+        // when, then
+        mockMvc.perform(post("/reserves/add")
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(addReserveRequestDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/reserve/model/CurrentReserveTest.java
+++ b/src/test/java/com/firstone/greenjangteo/reserve/model/CurrentReserveTest.java
@@ -1,0 +1,64 @@
+package com.firstone.greenjangteo.reserve.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import static com.firstone.greenjangteo.reserve.exception.message.InvalidExceptionMessage.INVALID_UPDATING_RESERVE_EXCEPTION;
+import static com.firstone.greenjangteo.reserve.testutil.ReserveTestConstant.RESERVE1;
+import static com.firstone.greenjangteo.reserve.testutil.ReserveTestConstant.RESERVE2;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@ActiveProfiles("test")
+class CurrentReserveTest {
+    @DisplayName("동일한 현재 적립금을 전송하면 동등한 CurrentReserve 인스턴스를 생성한다.")
+    @Test
+    void ofSameValue() {
+        // given, when
+        CurrentReserve currentReserve1 = new CurrentReserve(RESERVE1);
+        CurrentReserve currentReserve2 = new CurrentReserve(RESERVE1);
+
+        // then
+        assertThat(currentReserve1).isEqualTo(currentReserve2);
+        assertThat(currentReserve1.hashCode()).isEqualTo(currentReserve2.hashCode());
+    }
+
+    @DisplayName("다른 현재 적립금을 전송하면 동등하지 않은 CurrentReserve 인스턴스를 생성한다.")
+    @Test
+    void ofDifferentValue() {
+        // given, when
+        CurrentReserve currentReserve1 = new CurrentReserve(RESERVE1);
+        CurrentReserve currentReserve2 = new CurrentReserve(RESERVE2);
+
+        // then
+        assertThat(currentReserve1).isNotEqualTo(currentReserve2);
+        assertThat(currentReserve1.hashCode()).isNotEqualTo(currentReserve2.hashCode());
+    }
+
+    @DisplayName("현재 적립금과 추가할 적립금을 전송해 적립금을 추가할 수 있다.")
+    @Test
+    void addReserve() {
+        // given
+        CurrentReserve currentReserve = new CurrentReserve(RESERVE1);
+
+        // when
+        CurrentReserve addedCurrentReserve = CurrentReserve.addReserve(currentReserve, RESERVE2);
+
+        // then
+        assertThat(addedCurrentReserve.getValue()).isEqualTo(RESERVE1 + RESERVE2);
+    }
+
+    @DisplayName("전송된 추가할 적립금이 음수이면 IllegalArgumentException이 발생한다.")
+    @Test
+    void addReserveFromMinusValue() {
+        // given
+        CurrentReserve currentReserve = new CurrentReserve(RESERVE1);
+        int addedReserve = -RESERVE2;
+
+        // when, then
+        assertThatThrownBy(() -> CurrentReserve.addReserve(currentReserve, addedReserve))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(INVALID_UPDATING_RESERVE_EXCEPTION + addedReserve);
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/reserve/model/entity/ReserveHistoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/reserve/model/entity/ReserveHistoryTest.java
@@ -1,0 +1,60 @@
+package com.firstone.greenjangteo.reserve.model.entity;
+
+import com.firstone.greenjangteo.reserve.dto.request.AddReserveRequestDto;
+import com.firstone.greenjangteo.reserve.model.CurrentReserve;
+import com.firstone.greenjangteo.reserve.testutil.ReserveTestObjectFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.firstone.greenjangteo.reserve.testutil.ReserveTestConstant.RESERVE1;
+import static com.firstone.greenjangteo.reserve.testutil.ReserveTestConstant.RESERVE2;
+import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ReserveHistoryTest {
+    @DisplayName("올바른 값을 전송하면 적립금 내역 인스턴스를 생성할 수 있다.")
+    @Test
+    void from() {
+        // given
+        AddReserveRequestDto addReserveRequestDto
+                = ReserveTestObjectFactory.createAddReserveRequestDto(ID_EXAMPLE, RESERVE1);
+
+        // when
+        ReserveHistory reserveHistory = ReserveHistory.from(addReserveRequestDto, new CurrentReserve(RESERVE2));
+
+        // then
+        assertThat(reserveHistory.getUserId()).isEqualTo(Long.parseLong(ID_EXAMPLE));
+        assertThat(reserveHistory.getAddedReserve()).isEqualTo(RESERVE1);
+        assertThat(reserveHistory.getCurrentReserve()).isEqualTo(new CurrentReserve(RESERVE1 + RESERVE2));
+    }
+
+    @DisplayName("동일한 내부 값들을 전송하면 동등한 ReserveHistory 인스턴스를 생성한다.")
+    @Test
+    void fromSameValue() {
+        // given, when
+        AddReserveRequestDto addReserveRequestDto
+                = ReserveTestObjectFactory.createAddReserveRequestDto(ID_EXAMPLE, RESERVE1);
+
+        ReserveHistory reserveHistory1 = ReserveHistory.from(addReserveRequestDto, new CurrentReserve(RESERVE2));
+        ReserveHistory reserveHistory2 = ReserveHistory.from(addReserveRequestDto, new CurrentReserve(RESERVE2));
+
+        // then
+        assertThat(reserveHistory1).isEqualTo(reserveHistory2);
+        assertThat(reserveHistory1.hashCode()).isEqualTo(reserveHistory2.hashCode());
+    }
+
+    @DisplayName("다른 내부 값들을 전송하면 동등하지 않은 ReserveHistory 인스턴스를 생성한다.")
+    @Test
+    void fromDifferentValue() {
+        // given, when
+        AddReserveRequestDto addReserveRequestDto
+                = ReserveTestObjectFactory.createAddReserveRequestDto(ID_EXAMPLE, RESERVE1);
+
+        ReserveHistory reserveHistory1 = ReserveHistory.from(addReserveRequestDto, new CurrentReserve(RESERVE1));
+        ReserveHistory reserveHistory2 = ReserveHistory.from(addReserveRequestDto, new CurrentReserve(RESERVE2));
+
+        // then
+        assertThat(reserveHistory1).isNotEqualTo(reserveHistory2);
+        assertThat(reserveHistory1.hashCode()).isNotEqualTo(reserveHistory2.hashCode());
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/reserve/repository/ReserveHistoryRepositoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/reserve/repository/ReserveHistoryRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.firstone.greenjangteo.reserve.repository;
+
+import com.firstone.greenjangteo.reserve.model.CurrentReserve;
+import com.firstone.greenjangteo.reserve.model.entity.ReserveHistory;
+import com.firstone.greenjangteo.reserve.testutil.ReserveTestObjectFactory;
+import com.firstone.greenjangteo.user.model.entity.User;
+import com.firstone.greenjangteo.user.repository.UserRepository;
+import com.firstone.greenjangteo.user.testutil.UserTestObjectFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static com.firstone.greenjangteo.reserve.testutil.ReserveTestConstant.RESERVE1;
+import static com.firstone.greenjangteo.reserve.testutil.ReserveTestConstant.RESERVE2;
+import static com.firstone.greenjangteo.user.model.Role.ROLE_BUYER;
+import static com.firstone.greenjangteo.user.testutil.UserTestConstant.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ReserveHistoryRepositoryTest {
+    @Autowired
+    private ReserveHistoryRepository reserveHistoryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @DisplayName("회원 ID를 통해 가장 최신의 적립금 내역을 조회할 수 있다.")
+    @Test
+    void findFirstByUserIdOrderByCreatedAtDesc() {
+        // given
+        User user = UserTestObjectFactory.createUser(
+                EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.toString())
+        );
+        userRepository.save(user);
+
+        ReserveHistory reserveHistory1
+                = ReserveTestObjectFactory.createReserveHistory(user.getId(), RESERVE1, new CurrentReserve(RESERVE2));
+        ReserveHistory reserveHistory2 = ReserveTestObjectFactory
+                .createReserveHistory(user.getId(), RESERVE1, new CurrentReserve(RESERVE1 + RESERVE2));
+        reserveHistoryRepository.saveAll(List.of(reserveHistory1, reserveHistory2));
+
+        // when
+        ReserveHistory foundReserveHistory
+                = reserveHistoryRepository.findFirstByUserIdOrderByCreatedAtDesc(user.getId()).get();
+
+        // then
+        assertThat(foundReserveHistory.getAddedReserve()).isEqualTo(reserveHistory2.getAddedReserve());
+        assertThat(foundReserveHistory.getCurrentReserve()).isEqualTo(reserveHistory2.getCurrentReserve());
+        assertThat(foundReserveHistory.getCurrentReserve().getValue()).isEqualTo(2 * RESERVE1 + RESERVE2);
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/reserve/service/ReserveServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/reserve/service/ReserveServiceTest.java
@@ -1,0 +1,89 @@
+package com.firstone.greenjangteo.reserve.service;
+
+import com.firstone.greenjangteo.reserve.dto.request.AddReserveRequestDto;
+import com.firstone.greenjangteo.reserve.model.CurrentReserve;
+import com.firstone.greenjangteo.reserve.model.entity.ReserveHistory;
+import com.firstone.greenjangteo.reserve.repository.ReserveHistoryRepository;
+import com.firstone.greenjangteo.reserve.testutil.ReserveTestObjectFactory;
+import com.firstone.greenjangteo.user.model.entity.User;
+import com.firstone.greenjangteo.user.repository.UserRepository;
+import com.firstone.greenjangteo.user.testutil.UserTestObjectFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static com.firstone.greenjangteo.reserve.testutil.ReserveTestConstant.RESERVE1;
+import static com.firstone.greenjangteo.reserve.testutil.ReserveTestConstant.RESERVE2;
+import static com.firstone.greenjangteo.user.model.Role.ROLE_BUYER;
+import static com.firstone.greenjangteo.user.testutil.UserTestConstant.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ReserveServiceTest {
+    @Autowired
+    private ReserveService reserveService;
+
+    @Autowired
+    private ReserveHistoryRepository reserveHistoryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @DisplayName("회원의 적립금 내역을 생성할 수 있다.")
+    @Test
+    void createReserveHistory() {
+        // given
+        User user = UserTestObjectFactory.createUser(
+                EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.toString())
+        );
+        userRepository.save(user);
+
+        AddReserveRequestDto addReserveRequestDto
+                = ReserveTestObjectFactory.createAddReserveRequestDto(user.getId().toString(), RESERVE1);
+
+        // when
+        reserveService.addReserve(addReserveRequestDto);
+
+        // then
+        ReserveHistory reserveHistory
+                = reserveHistoryRepository.findFirstByUserIdOrderByCreatedAtDesc(user.getId()).get();
+
+        assertThat(reserveHistory.getCurrentReserve()).isEqualTo(new CurrentReserve(RESERVE1));
+    }
+
+    @DisplayName("회원의 적립금을 추가할 수 있다.")
+    @Test
+    void addReserve() {
+        // given
+        User user = UserTestObjectFactory.createUser(
+                EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.toString())
+        );
+        userRepository.save(user);
+
+        AddReserveRequestDto addReserveRequestDto1
+                = ReserveTestObjectFactory.createAddReserveRequestDto(user.getId().toString(), RESERVE1);
+        ReserveHistory firstReserveHistory = ReserveHistory.from(addReserveRequestDto1, new CurrentReserve(0));
+        reserveHistoryRepository.save(firstReserveHistory);
+
+        AddReserveRequestDto addReserveRequestDto2
+                = ReserveTestObjectFactory.createAddReserveRequestDto(user.getId().toString(), RESERVE2);
+
+        // when
+        reserveService.addReserve(addReserveRequestDto2);
+
+        // then
+        ReserveHistory currentReserveHistory
+                = reserveHistoryRepository.findFirstByUserIdOrderByCreatedAtDesc(user.getId()).get();
+
+        assertThat(currentReserveHistory.getCurrentReserve()).isEqualTo(new CurrentReserve(RESERVE1 + RESERVE2));
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/reserve/testutil/ReserveTestConstant.java
+++ b/src/test/java/com/firstone/greenjangteo/reserve/testutil/ReserveTestConstant.java
@@ -1,0 +1,6 @@
+package com.firstone.greenjangteo.reserve.testutil;
+
+public class ReserveTestConstant {
+    public static final int RESERVE1 = 1_000;
+    public static final int RESERVE2 = 2_000;
+}

--- a/src/test/java/com/firstone/greenjangteo/reserve/testutil/ReserveTestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/reserve/testutil/ReserveTestObjectFactory.java
@@ -1,0 +1,19 @@
+package com.firstone.greenjangteo.reserve.testutil;
+
+import com.firstone.greenjangteo.reserve.dto.request.AddReserveRequestDto;
+import com.firstone.greenjangteo.reserve.model.CurrentReserve;
+import com.firstone.greenjangteo.reserve.model.entity.ReserveHistory;
+
+public class ReserveTestObjectFactory {
+    public static AddReserveRequestDto createAddReserveRequestDto(String userId, int addedReserve) {
+        return new AddReserveRequestDto(userId, addedReserve);
+    }
+
+    public static ReserveHistory createReserveHistory(Long userId, int addedReserve, CurrentReserve currentReserve) {
+        return ReserveHistory.builder()
+                .userId(userId)
+                .addedReserve(addedReserve)
+                .currentReserve(CurrentReserve.addReserve(currentReserve, addedReserve))
+                .build();
+    }
+}


### PR DESCRIPTION
## resolve #239

## 추가사항

### 프로덕션 코드
- 적립금 추가 요청
- 적립금 내역(ReserveHistory) 엔티티 추가
- 적립금 추가 요청 비즈니스 로직
    - 새로운 적립금 내역 생성
    - 기존의 적립금에 적립금 추가
- 회원 ID를 통한 가장 최신의 적립금 내역 조회
- 201 status code 반환
- 비즈니스 로직의 로깅 AOP 추가
    - 적립금 추가

### 테스트 코드
- 적립금 추가 요청, 201 status code 응답
- 적립금 내역(ReserveHistory) 엔티티 생성
- 현재 적립금(CurrentReserve) 객체 생성
- 현재 적립금 객체에 적립금 추가
- 현재 적립금 액수에 대한 유효성 검사
- 적립금 추가 요청 비즈니스 로직
    - 새로운 적립금 내역 생성
    - 기존의 적립금에 적립금 추가
- 회원 ID를 통한 가장 최신의 적립금 내역 조회