### PR TITLE
[#247] 주문 시 쿠폰 사용 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/coupon/excpeption/message/AbnormalStateExceptionMessage.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/excpeption/message/AbnormalStateExceptionMessage.java
@@ -7,5 +7,6 @@ public class AbnormalStateExceptionMessage {
     public static final String INSUFFICIENT_REMAINING_QUANTITY_EXCEPTION
             = "쿠폰 그룹의 잔여 쿠폰 수량이 지급 예정 쿠폰 수량보다 부족합니다. 잔여 쿠폰 수량: ";
     public static final String INSUFFICIENT_REMAINING_QUANTITY_EXCEPTION_QUANTITY_TO_PROVIDE = ", 지급 예정 쿠폰 수량: ";
-    public static final String ALREADY_GIVEN_COUPON_EXCEPTION = "이미 다른 사용자에게 지급된 쿠폰입니다.";
+    public static final String ALREADY_GIVEN_COUPON_EXCEPTION = "이미 다른 사용자에게 지급된 쿠폰입니다. 회원 ID: ";
+    public static final String ALREADY_USED_COUPON_EXCEPTION = "이미 사용된 쿠폰입니다. 사용된 주문 ID: ";
 }

--- a/src/main/java/com/firstone/greenjangteo/coupon/excpeption/serious/AlreadyUsedCouponException.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/excpeption/serious/AlreadyUsedCouponException.java
@@ -1,0 +1,15 @@
+package com.firstone.greenjangteo.coupon.excpeption.serious;
+
+import com.firstone.greenjangteo.exception.AbstractSeriousException;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyUsedCouponException extends AbstractSeriousException {
+    public AlreadyUsedCouponException(String message) {
+        super(message);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.CONFLICT.value();
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/coupon/model/entity/Coupon.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/model/entity/Coupon.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.firstone.greenjangteo.coupon.excpeption.serious.AlreadyProvidedCouponException;
+import com.firstone.greenjangteo.coupon.excpeption.serious.AlreadyUsedCouponException;
 import com.firstone.greenjangteo.coupon.model.ExpirationPeriod;
 import com.firstone.greenjangteo.user.model.entity.User;
 import lombok.AccessLevel;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 
 import static com.firstone.greenjangteo.coupon.excpeption.message.AbnormalStateExceptionMessage.ALREADY_GIVEN_COUPON_EXCEPTION;
+import static com.firstone.greenjangteo.coupon.excpeption.message.AbnormalStateExceptionMessage.ALREADY_USED_COUPON_EXCEPTION;
 
 @Entity(name = "coupon")
 @Table(name = "coupon")
@@ -102,6 +104,15 @@ public class Coupon {
             return;
         }
 
-        throw new AlreadyProvidedCouponException(ALREADY_GIVEN_COUPON_EXCEPTION);
+        throw new AlreadyProvidedCouponException(ALREADY_GIVEN_COUPON_EXCEPTION + user.getId());
+    }
+
+    public void addOrderId(Long orderId) {
+        if (usedOrderId == null) {
+            usedOrderId = orderId;
+            return;
+        }
+
+        throw new AlreadyUsedCouponException(ALREADY_USED_COUPON_EXCEPTION + usedOrderId);
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/coupon/service/CouponService.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/service/CouponService.java
@@ -20,7 +20,10 @@ public interface CouponService {
 
     void provideCouponsToUser(ProvideCouponsToUserRequestDto provideCouponsToUserRequestDto);
 
-    List<Coupon> getCoupons(long userId);
+    List<Coupon> getCoupons(Long userId);
+
+    int updateUsedCoupon(Long orderId, Long couponId);
 
     void deleteCoupon(long couponId);
 }
+

--- a/src/main/java/com/firstone/greenjangteo/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/service/CouponServiceImpl.java
@@ -123,8 +123,17 @@ public class CouponServiceImpl implements CouponService {
 
     @Override
     @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 15)
-    public List<Coupon> getCoupons(long userId) {
+    public List<Coupon> getCoupons(Long userId) {
         return couponRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public int updateUsedCoupon(Long orderId, Long couponId) {
+        Coupon coupon = getCoupon(couponId);
+        coupon.addOrderId(orderId);
+        couponRepository.save(coupon);
+
+        return coupon.getCouponGroup().getAmount().getValue();
     }
 
     @Override
@@ -151,5 +160,10 @@ public class CouponServiceImpl implements CouponService {
         couponGroup.issueAndAddUserToCoupons(user, coupons, requiredQuantity);
 
         couponRepository.saveAll(coupons);
+    }
+
+    private Coupon getCoupon(long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseThrow(() -> new EntityNotFoundException(COUPON_ID_NOT_FOUND_EXCEPTION + couponId));
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/order/dto/request/UseCouponRequestDto.java
+++ b/src/main/java/com/firstone/greenjangteo/order/dto/request/UseCouponRequestDto.java
@@ -1,0 +1,22 @@
+package com.firstone.greenjangteo.order.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.firstone.greenjangteo.coupon.controller.CouponController.COUPON_ID;
+import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
+import static com.firstone.greenjangteo.web.ApiConstant.USER_ID_VALUE;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class UseCouponRequestDto {
+    @ApiModelProperty(value = USER_ID_VALUE, example = ID_EXAMPLE)
+    private String userId;
+
+    @ApiModelProperty(value = COUPON_ID, example = ID_EXAMPLE)
+    private String couponId;
+}

--- a/src/main/java/com/firstone/greenjangteo/order/model/TotalOrderPrice.java
+++ b/src/main/java/com/firstone/greenjangteo/order/model/TotalOrderPrice.java
@@ -4,6 +4,8 @@ import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 import java.util.Objects;
 
+import static com.firstone.greenjangteo.order.excpeption.message.InvalidExceptionMessage.INVALID_ORDER_PRICE_EXCEPTION;
+
 public class TotalOrderPrice {
     private final int totalOrderPrice;
 
@@ -32,6 +34,19 @@ public class TotalOrderPrice {
 
     public int getValue() {
         return totalOrderPrice;
+    }
+
+    public int computeOrderPriceAfterUpdate(int usedCouponAmount, int usedReserveAmount) {
+        int orderPriceAfterCouponUsed = totalOrderPrice - (usedCouponAmount + usedReserveAmount);
+        validateOrderPriceAfterUpdate(orderPriceAfterCouponUsed);
+
+        return orderPriceAfterCouponUsed;
+    }
+
+    private static void validateOrderPriceAfterUpdate(int totalOrderPriceAfterUpdate) {
+        if (totalOrderPriceAfterUpdate < 0) {
+            throw new IllegalArgumentException(INVALID_ORDER_PRICE_EXCEPTION + totalOrderPriceAfterUpdate);
+        }
     }
 
     @Converter

--- a/src/main/java/com/firstone/greenjangteo/order/model/entity/Order.java
+++ b/src/main/java/com/firstone/greenjangteo/order/model/entity/Order.java
@@ -47,6 +47,9 @@ public class Order extends BaseEntity {
     @Column(nullable = false)
     private TotalOrderPrice totalOrderPrice;
 
+    private int usedCouponAmount;
+    private int usedReserveAmount;
+
     @Embedded
     private Address shippingAddress;
 
@@ -95,5 +98,11 @@ public class Order extends BaseEntity {
     @Override
     public int hashCode() {
         return Objects.hash(id, store, buyer, orderStatus, totalOrderPrice, shippingAddress);
+    }
+
+    public int updateCouponAmount(int couponAmount) {
+        usedCouponAmount += couponAmount;
+
+        return totalOrderPrice.computeOrderPriceAfterUpdate(usedCouponAmount, usedReserveAmount);
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/order/service/OrderService.java
+++ b/src/main/java/com/firstone/greenjangteo/order/service/OrderService.java
@@ -16,5 +16,7 @@ public interface OrderService {
 
     Order getOrder(Long orderId);
 
+    int useCoupon(Long orderId, Long couponId);
+
     void deleteOrder(Long orderId, UserIdRequestDto userIdRequestDto);
 }

--- a/src/main/java/com/firstone/greenjangteo/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/order/service/OrderServiceImpl.java
@@ -2,6 +2,7 @@ package com.firstone.greenjangteo.order.service;
 
 import com.firstone.greenjangteo.cart.domain.dto.response.CartProductListResponseDto;
 import com.firstone.greenjangteo.cart.service.CartService;
+import com.firstone.greenjangteo.coupon.service.CouponService;
 import com.firstone.greenjangteo.order.dto.request.CartOrderRequestDto;
 import com.firstone.greenjangteo.order.dto.request.OrderProductRequestDto;
 import com.firstone.greenjangteo.order.dto.request.OrderRequestDto;
@@ -9,6 +10,7 @@ import com.firstone.greenjangteo.order.model.entity.Order;
 import com.firstone.greenjangteo.order.repository.OrderRepository;
 import com.firstone.greenjangteo.product.domain.model.Product;
 import com.firstone.greenjangteo.product.service.ProductService;
+import com.firstone.greenjangteo.reserve.service.ReserveService;
 import com.firstone.greenjangteo.user.domain.store.model.entity.Store;
 import com.firstone.greenjangteo.user.domain.store.service.StoreService;
 import com.firstone.greenjangteo.user.dto.request.UserIdRequestDto;
@@ -35,6 +37,8 @@ public class OrderServiceImpl implements OrderService {
     private final UserService userService;
     private final ProductService productService;
     private final CartService cartService;
+    private final CouponService couponService;
+    private final ReserveService reserveService;
     private final OrderRepository orderRepository;
 
     @Override
@@ -87,6 +91,17 @@ public class OrderServiceImpl implements OrderService {
     public Order getOrder(Long orderId) {
         return orderRepository.findById(orderId)
                 .orElseThrow(() -> new EntityNotFoundException(ORDER_ID_NOT_FOUND_EXCEPTION + orderId));
+    }
+
+    @Override
+    public int useCoupon(Long orderId, Long couponId) {
+        int couponAmount = couponService.updateUsedCoupon(orderId, couponId);
+        Order order = getOrder(orderId);
+
+        int totalOrderPriceAfterCouponUsed = order.updateCouponAmount(couponAmount);
+        orderRepository.save(order);
+
+        return totalOrderPriceAfterCouponUsed;
     }
 
     @Override

--- a/src/test/java/com/firstone/greenjangteo/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/coupon/service/CouponServiceTest.java
@@ -3,6 +3,7 @@ package com.firstone.greenjangteo.coupon.service;
 import com.firstone.greenjangteo.coupon.dto.request.IssueCouponsRequestDto;
 import com.firstone.greenjangteo.coupon.dto.request.ProvideCouponsToUserRequestDto;
 import com.firstone.greenjangteo.coupon.dto.request.ProvideCouponsToUsersRequestDto;
+import com.firstone.greenjangteo.coupon.excpeption.serious.AlreadyUsedCouponException;
 import com.firstone.greenjangteo.coupon.model.Amount;
 import com.firstone.greenjangteo.coupon.model.ExpirationPeriod;
 import com.firstone.greenjangteo.coupon.model.IssueQuantity;
@@ -31,10 +32,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.firstone.greenjangteo.coupon.excpeption.message.AbnormalStateExceptionMessage.ALREADY_USED_COUPON_EXCEPTION;
 import static com.firstone.greenjangteo.coupon.testutil.CouponTestConstant.*;
 import static com.firstone.greenjangteo.user.model.Role.ROLE_BUYER;
 import static com.firstone.greenjangteo.user.testutil.UserTestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -65,8 +68,8 @@ class CouponServiceTest {
 
     @AfterEach
     void tearDown() {
-        couponGroupRepository.deleteAll();
         couponRepository.deleteAll();
+        couponGroupRepository.deleteAll();
     }
 
     @DisplayName("올바른 쿠폰 발행 양식을 전송하면 대량의 쿠폰을 등록할 수 있다.")
@@ -275,6 +278,58 @@ class CouponServiceTest {
         assertThat(foundCoupons).hasSize(coupons2.size())
                 .extracting("couponGroup")
                 .containsOnly(couponGroup2);
+    }
+
+    @DisplayName("쿠폰을 주문에 사용할 수 있다.")
+    @Test
+    @Transactional
+    void updateUsedCoupon() {
+        // given
+        Long orderId = 1L;
+
+        CouponGroup couponGroup = CouponTestObjectFactory.createCouponGroup(
+                COUPON_NAME1, AMOUNT, DESCRIPTION, ISSUE_QUANTITY1, tomorrow, EXPIRATION_PERIOD1
+        );
+        couponGroupRepository.save(couponGroup);
+
+        List<Coupon> coupons = CouponTestObjectFactory.createCoupons(couponGroup);
+        couponRepository.saveAll(coupons);
+
+        Coupon coupon1 = coupons.get(0);
+        Coupon coupon2 = coupons.get(1);
+
+        // when
+        couponService.updateUsedCoupon(orderId, coupon1.getId());
+
+        // then
+        assertThat(coupon1.getUsedOrderId()).isEqualTo(orderId);
+        assertThat(coupon2.getUsedOrderId()).isNull();
+    }
+
+    @DisplayName("이미 사용된 쿠폰을 사용하려 하면 AlreadyUsedCouponException이 발생한다.")
+    @Test
+    @Transactional
+    void updateAlreadyUsedCoupon() {
+        // given
+        Long orderId1 = 1L;
+        Long orderId2 = 2L;
+
+        CouponGroup couponGroup = CouponTestObjectFactory.createCouponGroup(
+                COUPON_NAME1, AMOUNT, DESCRIPTION, ISSUE_QUANTITY1, tomorrow, EXPIRATION_PERIOD1
+        );
+        couponGroupRepository.save(couponGroup);
+
+        List<Coupon> coupons = CouponTestObjectFactory.createCoupons(couponGroup);
+        couponRepository.saveAll(coupons);
+
+        Coupon coupon = coupons.get(0);
+
+        couponService.updateUsedCoupon(orderId1, coupon.getId());
+
+        // when, then
+        assertThatThrownBy(() -> couponService.updateUsedCoupon(orderId2, coupon.getId()))
+                .isInstanceOf(AlreadyUsedCouponException.class)
+                .hasMessage(ALREADY_USED_COUPON_EXCEPTION + orderId1);
     }
 
     @DisplayName("쿠폰 ID를 통해 쿠폰을 삭제할 수 있다.")

--- a/src/test/java/com/firstone/greenjangteo/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/order/controller/OrderControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.firstone.greenjangteo.order.dto.request.CartOrderRequestDto;
 import com.firstone.greenjangteo.order.dto.request.OrderProductRequestDto;
 import com.firstone.greenjangteo.order.dto.request.OrderRequestDto;
+import com.firstone.greenjangteo.order.dto.request.UseCouponRequestDto;
 import com.firstone.greenjangteo.order.model.entity.Order;
 import com.firstone.greenjangteo.order.service.OrderService;
 import com.firstone.greenjangteo.order.testutil.OrderTestObjectFactory;
@@ -27,6 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
+import static com.firstone.greenjangteo.order.testutil.OrderTestConstant.PRICE1;
 import static com.firstone.greenjangteo.order.testutil.OrderTestConstant.*;
 import static com.firstone.greenjangteo.user.domain.store.testutil.StoreTestConstant.PRICE2;
 import static com.firstone.greenjangteo.user.domain.store.testutil.StoreTestConstant.*;
@@ -232,6 +234,23 @@ class OrderControllerTest {
         mockMvc.perform(get("/orders/{orderId}", order.getId())
                         .with(csrf())
                         .queryParam("userId", BUYER_ID))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("주문에 쿠폰을 적용할 수 있다.")
+    @Test
+    @WithMockUser(username = BUYER_ID, roles = {"BUYER"})
+    void useCoupon() throws Exception {
+        // given
+        UseCouponRequestDto useCouponRequestDto = new UseCouponRequestDto(BUYER_ID, ORDER_ID);
+        when(orderService.useCoupon(anyLong(), anyLong())).thenReturn(PRICE1);
+
+        // when, then
+        mockMvc.perform(patch("/orders/{orderId}/coupon-usage", ORDER_ID)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(useCouponRequestDto))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/firstone/greenjangteo/order/testutil/OrderTestConstant.java
+++ b/src/test/java/com/firstone/greenjangteo/order/testutil/OrderTestConstant.java
@@ -12,4 +12,5 @@ public class OrderTestConstant {
     public static final String CART_ID = "1";
     public static final int PRICE1 = 30_000;
     public static final int PRICE2 = 50_000;
+    public static final int PRICE3 = 100_000;
 }


### PR DESCRIPTION
## resolve #247

## 설명
- 주문 시 쿠폰 사용 기능

## 추가사항

### 프로덕션 코드
- 쿠폰 사용 요청
- 쿠폰 사용 요청 비즈니스 로직
    - 쿠폰에 주문 ID 추가
    - 이미 사용된 쿠폰일 시 예외 처리
    - 주문에 사용된 쿠폰 금액 추가
    - 쿠폰과 적립금의 총 사용 금액이 총 주문 금액을 초과할 시 예외 처리
- 200 status code 반환

### 테스트 코드
- 쿠폰 사용 요청, 200 status code 응답
- 쿠폰 사용 요청 비즈니스 로직
    - 쿠폰에 주문 ID 추가
    - 이미 사용된 쿠폰일 시 예외 처리
    - 주문에 사용된 쿠폰 금액 추가
    - 쿠폰과 적립금의 총 사용 금액이 총 주문 금액을 초과할 시 예외 처리