### PR TITLE
[#248] 주문 쿠폰 사용 취소 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/coupon/exception/serious/NotUsedCouponException.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/exception/serious/NotUsedCouponException.java
@@ -1,0 +1,15 @@
+package com.firstone.greenjangteo.coupon.exception.serious;
+
+import com.firstone.greenjangteo.exception.AbstractSeriousException;
+import org.springframework.http.HttpStatus;
+
+public class NotUsedCouponException extends AbstractSeriousException {
+    public NotUsedCouponException(String message) {
+        super(message);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.CONFLICT.value();
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/coupon/model/entity/Coupon.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/model/entity/Coupon.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.firstone.greenjangteo.coupon.exception.serious.AlreadyProvidedCouponException;
 import com.firstone.greenjangteo.coupon.exception.serious.AlreadyUsedCouponException;
+import com.firstone.greenjangteo.coupon.exception.serious.NotUsedCouponException;
 import com.firstone.greenjangteo.coupon.model.ExpirationPeriod;
 import com.firstone.greenjangteo.user.model.entity.User;
 import lombok.AccessLevel;
@@ -113,5 +114,13 @@ public class Coupon {
         }
 
         throw new AlreadyUsedCouponException(ALREADY_USED_COUPON_EXCEPTION + usedOrderId);
+    }
+
+    public void removeOrderId(Long orderId) {
+        if (usedOrderId == null) {
+            throw new NotUsedCouponException(NOT_USED_COUPON_EXCEPTION);
+        }
+
+        usedOrderId = null;
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/coupon/service/CouponService.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/service/CouponService.java
@@ -24,6 +24,8 @@ public interface CouponService {
 
     int updateUsedCoupon(Long orderId, Long couponId);
 
+    int rollBackUsedCoupon(Long orderId, Long couponId);
+
     void deleteCoupon(long couponId);
 }
 

--- a/src/main/java/com/firstone/greenjangteo/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/service/CouponServiceImpl.java
@@ -25,7 +25,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.firstone.greenjangteo.coupon.excpeption.message.NotFoundExceptionMessage.COUPON_ID_NOT_FOUND_EXCEPTION;
+import static com.firstone.greenjangteo.coupon.exception.message.NotFoundExceptionMessage.COUPON_ID_NOT_FOUND_EXCEPTION;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
 @Service
@@ -131,6 +131,15 @@ public class CouponServiceImpl implements CouponService {
     public int updateUsedCoupon(Long orderId, Long couponId) {
         Coupon coupon = getCoupon(couponId);
         coupon.addOrderId(orderId);
+        couponRepository.save(coupon);
+
+        return coupon.getCouponGroup().getAmount().getValue();
+    }
+
+    @Override
+    public int rollBackUsedCoupon(Long orderId, Long couponId) {
+        Coupon coupon = getCoupon(couponId);
+        coupon.removeOrderId(orderId);
         couponRepository.save(coupon);
 
         return coupon.getCouponGroup().getAmount().getValue();

--- a/src/main/java/com/firstone/greenjangteo/order/controller/OrderController.java
+++ b/src/main/java/com/firstone/greenjangteo/order/controller/OrderController.java
@@ -53,6 +53,10 @@ public class OrderController {
     private static final String COUPON_USAGE_DESCRIPTION = "주문 ID와 구매자 ID를 입력해 주문에 쿠폰을 적용할 수 있습니다.";
     private static final String COUPON_USAGE_FORM = "쿠폰 적용 요청 양식";
 
+    private static final String COUPON_USAGE_CANCEL = "쿠폰 적용 취소";
+    private static final String COUPON_USAGE_CANCEL_DESCRIPTION = "주문 ID와 구매자 ID를 입력해 주문에 쿠폰 적용을 취소할 수 있습니다.";
+    private static final String COUPON_USAGE_CANCEL_FORM = "쿠폰 적용 취소 요청 양식";
+
     private static final String DELETE_ORDER = "주문 삭제";
     private static final String DELETE_ORDER_DESCRIPTION = "주문 ID와 구매자 ID를 입력해 주문을 삭제할 수 있습니다.";
 
@@ -125,6 +129,25 @@ public class OrderController {
         RoleValidator.checkAdminOrPrincipalAuthentication(useCouponRequestDto.getUserId());
 
         int totalOrderPriceAfterCouponUsed = orderService.useCoupon(Long.parseLong(orderId), Long.parseLong(couponId));
+
+        return ResponseEntity.status(HttpStatus.OK).body(totalOrderPriceAfterCouponUsed);
+    }
+
+    @ApiOperation(value = COUPON_USAGE_CANCEL, notes = COUPON_USAGE_CANCEL_DESCRIPTION)
+    @PatchMapping("/{orderId}/coupon-cancel")
+    public ResponseEntity<Integer> cancelCoupon
+            (@PathVariable("orderId") @ApiParam(value = ORDER_ID, example = ID_EXAMPLE) String orderId,
+             @RequestBody @ApiParam(value = COUPON_USAGE_CANCEL_FORM) UseCouponRequestDto useCouponRequestDto) {
+        String couponId = useCouponRequestDto.getCouponId();
+
+        InputFormatValidator.validateId(orderId);
+        InputFormatValidator.validateId(useCouponRequestDto.getUserId());
+        InputFormatValidator.validateId(couponId);
+
+        RoleValidator.checkAdminOrPrincipalAuthentication(useCouponRequestDto.getUserId());
+
+        int totalOrderPriceAfterCouponUsed
+                = orderService.cancelCoupon(Long.parseLong(orderId), Long.parseLong(couponId));
 
         return ResponseEntity.status(HttpStatus.OK).body(totalOrderPriceAfterCouponUsed);
     }

--- a/src/main/java/com/firstone/greenjangteo/order/excpeption/message/InvalidExceptionMessage.java
+++ b/src/main/java/com/firstone/greenjangteo/order/excpeption/message/InvalidExceptionMessage.java
@@ -3,4 +3,6 @@ package com.firstone.greenjangteo.order.excpeption.message;
 public class InvalidExceptionMessage {
     public static final String INVALID_ORDER_QUANTITY_EXCEPTION
             = "주문 수량은 양의 정수(1 이상의 숫자)여야 합니다. 입력된 주문 수량: ";
+    public static final String INVALID_ORDER_PRICE_EXCEPTION
+            = "쿠폰과 적립금 적용 후 주문 가격은 양의 정수(1 이상의 숫자)여야 합니다. 현재 주문 가격: ";
 }

--- a/src/main/java/com/firstone/greenjangteo/order/service/OrderService.java
+++ b/src/main/java/com/firstone/greenjangteo/order/service/OrderService.java
@@ -18,5 +18,7 @@ public interface OrderService {
 
     int useCoupon(Long orderId, Long couponId);
 
+    int cancelCoupon(Long orderId, Long couponId);
+
     void deleteOrder(Long orderId, UserIdRequestDto userIdRequestDto);
 }

--- a/src/main/java/com/firstone/greenjangteo/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/order/service/OrderServiceImpl.java
@@ -105,6 +105,17 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
+    public int cancelCoupon(Long orderId, Long couponId) {
+        int couponAmount = couponService.rollBackUsedCoupon(orderId, couponId);
+        Order order = getOrder(orderId);
+
+        int totalOrderPriceAfterCouponUsed = order.updateCouponAmount(-couponAmount);
+        orderRepository.save(order);
+
+        return totalOrderPriceAfterCouponUsed;
+    }
+
+    @Override
     public void deleteOrder(Long orderId, UserIdRequestDto userIdRequestDto) {
         Long buyerId = Long.parseLong(userIdRequestDto.getUserId());
 

--- a/src/test/java/com/firstone/greenjangteo/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/order/controller/OrderControllerTest.java
@@ -255,6 +255,23 @@ class OrderControllerTest {
                 .andExpect(status().isOk());
     }
 
+    @DisplayName("주문에 적용한 쿠폰을 취소할 수 있다.")
+    @Test
+    @WithMockUser(username = BUYER_ID, roles = {"BUYER"})
+    void cancelCoupon() throws Exception {
+        // given
+        UseCouponRequestDto useCouponRequestDto = new UseCouponRequestDto(BUYER_ID, ORDER_ID);
+        when(orderService.cancelCoupon(anyLong(), anyLong())).thenReturn(PRICE1);
+
+        // when, then
+        mockMvc.perform(patch("/orders/{orderId}/coupon-cancel", ORDER_ID)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(useCouponRequestDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
     @DisplayName("주문 ID와 구매자 ID를 입력해 주문을 삭제할 수 있다.")
     @Test
     @WithMockUser(username = BUYER_ID, roles = {"BUYER"})


### PR DESCRIPTION
## resolve #248

## 추가사항

### 프로덕션 코드
- 쿠폰 사용 취소 요청
- 쿠폰 사용 취소 요청 비즈니스 로직
    - 쿠폰에서 주문 ID 제거
    - 아직 사용되지 않은 쿠폰일 시 예외 처리
    - 주문에서 사용된 쿠폰 금액 제거
- 200 status code 반환

### 테스트 코드
- 쿠폰 사용 취소 요청, 200 status code 응답
- 쿠폰 사용 취소 요청 비즈니스 로직
    - 쿠폰에서 주문 ID 제거
    - 아직 사용되지 않은 쿠폰일 시 예외 처리
    - 주문에서 사용된 쿠폰 금액 제거