### PR TITLE
[#263] 로그인 시 리프레시 토큰 발급 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/user/controller/AuthenticationController.java
+++ b/src/main/java/com/firstone/greenjangteo/user/controller/AuthenticationController.java
@@ -1,5 +1,6 @@
 package com.firstone.greenjangteo.user.controller;
 
+import com.firstone.greenjangteo.user.domain.token.service.TokenService;
 import com.firstone.greenjangteo.user.dto.request.DeleteRequestDto;
 import com.firstone.greenjangteo.user.dto.request.EmailRequestDto;
 import com.firstone.greenjangteo.user.dto.request.PasswordUpdateRequestDto;
@@ -9,7 +10,6 @@ import com.firstone.greenjangteo.user.dto.response.SignUpResponseDto;
 import com.firstone.greenjangteo.user.form.SignInForm;
 import com.firstone.greenjangteo.user.form.SignUpForm;
 import com.firstone.greenjangteo.user.model.entity.User;
-import com.firstone.greenjangteo.user.security.JwtTokenProvider;
 import com.firstone.greenjangteo.user.service.AuthenticationService;
 import com.firstone.greenjangteo.utility.InputFormatValidator;
 import io.swagger.annotations.ApiOperation;
@@ -34,7 +34,7 @@ import static com.firstone.greenjangteo.web.ApiConstant.*;
 @RequiredArgsConstructor
 public class AuthenticationController {
     private final AuthenticationService authenticationService;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenService tokenService;
 
     private static final String SIGN_UP = "회원 가입";
     private static final String SIGN_UP_DESCRIPTION = "회원 가입 양식을 입력해 회원 가입을 할 수 있습니다.";
@@ -77,9 +77,10 @@ public class AuthenticationController {
     public ResponseEntity<SignInResponseDto> signInUser
             (@RequestBody @ApiParam(value = SIGN_IN_FORM) SignInForm signInForm) {
         User user = authenticationService.signInUser(signInForm);
-        String token = jwtTokenProvider.generateToken(String.valueOf(user.getId()), user.getRoles().toStrings());
+        String accessToken = tokenService.issueAccessToken(user);
+        String refreshToken = tokenService.issueRefreshToken(user);
 
-        return ResponseEntity.status(HttpStatus.OK).body(SignInResponseDto.from(user, token));
+        return ResponseEntity.status(HttpStatus.OK).body(SignInResponseDto.from(user, accessToken, refreshToken));
     }
 
     @ApiOperation(value = UPDATE_EMAIL, notes = UPDATE_UPDATE_EMAIL_DESCRIPTION)

--- a/src/main/java/com/firstone/greenjangteo/user/domain/token/model/entity/RefreshToken.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/token/model/entity/RefreshToken.java
@@ -1,0 +1,38 @@
+package com.firstone.greenjangteo.user.domain.token.model.entity;
+
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity(name = "refresh_token")
+@Table(name = "refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "refresh_token_roles", joinColumns = @JoinColumn(name = "refresh_token_id"))
+    @Column(name = "role")
+    List<String> roles;
+
+    @Column(nullable = false)
+    private String token;
+
+    private RefreshToken(Long userId, List<String> roles, String token) {
+        this.userId = userId;
+        this.roles = roles;
+        this.token = token;
+    }
+
+    public static RefreshToken from(Long id, List<String> roles, String token) {
+        return new RefreshToken(id, roles, token);
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/user/domain/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.firstone.greenjangteo.user.domain.token.repository;
+
+import com.firstone.greenjangteo.user.domain.token.model.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/firstone/greenjangteo/user/domain/token/service/TokenService.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/token/service/TokenService.java
@@ -1,0 +1,30 @@
+package com.firstone.greenjangteo.user.domain.token.service;
+
+import com.firstone.greenjangteo.user.domain.token.model.entity.RefreshToken;
+import com.firstone.greenjangteo.user.domain.token.repository.RefreshTokenRepository;
+import com.firstone.greenjangteo.user.model.entity.User;
+import com.firstone.greenjangteo.user.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public String issueAccessToken(User user) {
+        String accessToken
+                = jwtTokenProvider.generateAccessToken(String.valueOf(user.getId()), user.getRoles().toStrings());
+
+        return accessToken;
+    }
+
+    public String issueRefreshToken(User user) {
+        String refreshToken
+                = jwtTokenProvider.generateRefreshToken(String.valueOf(user.getId()), user.getRoles().toStrings());
+        refreshTokenRepository.save(RefreshToken.from(user.getId(), user.getRoles().toStrings(), refreshToken));
+
+        return refreshToken;
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/user/dto/response/SignInResponseDto.java
+++ b/src/main/java/com/firstone/greenjangteo/user/dto/response/SignInResponseDto.java
@@ -24,14 +24,16 @@ public class SignInResponseDto {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private final LocalDateTime loggedInAt;
 
-    private final String token;
+    private final String accessToken;
+    private final String refreshToken;
 
-    public static SignInResponseDto from(User user, String token) {
+    public static SignInResponseDto from(User user, String accessToken, String refreshToken) {
         return SignInResponseDto.builder()
                 .userId(user.getId())
                 .roleDescriptions(user.getRoles().toDescriptions())
                 .loggedInAt(user.getLastLoggedInAt())
-                .token(token)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/user/security/JwtTokenProvider.java
+++ b/src/main/java/com/firstone/greenjangteo/user/security/JwtTokenProvider.java
@@ -22,7 +22,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
     private static final String KEY_ROLES = "roles";
-    private static final long LOGIN_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 2;
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 2;
+    private static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7;
     private final UserDetailsService userDetailsService;
 
     @Value("${spring.jwt.secret}")
@@ -33,13 +34,29 @@ public class JwtTokenProvider {
         secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
     }
 
-    public String generateToken(String userId, List<String> roles) {
+    public String generateAccessToken(String userId, List<String> roles) {
 
         Claims claims = Jwts.claims().setSubject(userId);
         claims.put(KEY_ROLES, roles);
 
         Date now = new Date();
-        Date expirationDate = new Date(now.getTime() + LOGIN_TOKEN_EXPIRATION_TIME);
+        Date expirationDate = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION_TIME);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expirationDate)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(String userId, List<String> roles) {
+
+        Claims claims = Jwts.claims().setSubject(userId);
+        claims.put(KEY_ROLES, roles);
+
+        Date now = new Date();
+        Date expirationDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME);
 
         return Jwts.builder()
                 .setClaims(claims)

--- a/src/test/java/com/firstone/greenjangteo/user/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/user/controller/AuthenticationControllerTest.java
@@ -1,6 +1,7 @@
 package com.firstone.greenjangteo.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.firstone.greenjangteo.user.domain.token.service.TokenService;
 import com.firstone.greenjangteo.user.dto.request.DeleteRequestDto;
 import com.firstone.greenjangteo.user.dto.request.EmailRequestDto;
 import com.firstone.greenjangteo.user.dto.request.PasswordUpdateRequestDto;
@@ -48,6 +49,9 @@ class AuthenticationControllerTest {
 
     @MockBean
     private AuthenticationService authenticationService;
+
+    @MockBean
+    private TokenService tokenService;
 
     @MockBean
     private PasswordEncoder passwordEncoder;

--- a/src/test/java/com/firstone/greenjangteo/user/domain/token/service/TokenServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/user/domain/token/service/TokenServiceTest.java
@@ -1,0 +1,64 @@
+package com.firstone.greenjangteo.user.domain.token.service;
+
+import com.firstone.greenjangteo.user.domain.token.repository.RefreshTokenRepository;
+import com.firstone.greenjangteo.user.model.entity.User;
+import com.firstone.greenjangteo.user.testutil.UserTestObjectFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.firstone.greenjangteo.user.model.Role.ROLE_BUYER;
+import static com.firstone.greenjangteo.user.testutil.UserTestConstant.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class TokenServiceTest {
+    @Autowired
+    private TokenService tokenService;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @DisplayName("엑세스 토큰을 발급할 수 있다.")
+    @Test
+    void issueAccessToken() {
+        // given
+        User user = UserTestObjectFactory.createUser(
+                EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.toString())
+        );
+
+        // when
+        String accessToken = tokenService.issueAccessToken(user);
+
+        // then
+        assertThat(accessToken).isNotBlank();
+    }
+
+    @DisplayName("리프레시 토큰을 발급하고 저장할 수 있다.")
+    @Test
+    void refreshAccessToken() {
+        // given
+        User user = UserTestObjectFactory.createUser(
+                1L, EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.toString())
+        );
+
+        // when
+        String createdRefreshToken = tokenService.issueRefreshToken(user);
+        String foundRefreshToken = refreshTokenRepository.findAll().get(0).getTokenValue();
+
+        // then
+        assertThat(createdRefreshToken).isNotBlank();
+        assertThat(foundRefreshToken).isEqualTo(createdRefreshToken);
+    }
+}


### PR DESCRIPTION
## resolve #263

## 추가사항

### 프로덕션 코드
- 로그인 시 엑세스 토큰 발급 요청 비즈니스 로직
- 로그인 시 리프레시 토큰 발급 요청 비즈니스 로직
- JwtTokenProvider 클래스에서 리프레시 토큰 생성
- 생성된 리프레시 토큰 데이터 저장
- 200 status code 반환

### 테스트 코드
- 로그인 시 엑세스 토큰 발급 요청 비즈니스 로직
- 로그인 시 리프레시 토큰 발급 요청 비즈니스 로직