### PR TITLE
[#264] 리프레시 토큰을 통한 엑세스 토큰 재발급 기능 추가

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/user/domain/token/controller/TokenController.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/token/controller/TokenController.java
@@ -1,0 +1,35 @@
+package com.firstone.greenjangteo.user.domain.token.controller;
+
+import com.firstone.greenjangteo.user.domain.token.service.TokenService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/token")
+@RequiredArgsConstructor
+public class TokenController {
+    private final TokenService tokenService;
+
+    private static final String ISSUE_NEW_ACCESS_TOKEN = "리프레시 토큰을 통해 새로운 엑세스 토큰 발급";
+    private static final String ISSUE_NEW_ACCESS_TOKEN_DESCRIPTION
+            = "리프레시 토큰을 입력해 새로운 엑세스 토큰을 발급 받을 수 있습니다.";
+    private static final String REFRESH_TOKEN = "리프레시 토큰";
+    private static final String REFRESH_TOKEN_EXAMPLE = "refreshTokenValue";
+
+    @ApiOperation(value = ISSUE_NEW_ACCESS_TOKEN, notes = ISSUE_NEW_ACCESS_TOKEN_DESCRIPTION)
+    @PostMapping()
+    public ResponseEntity<String> issueNewAccessToken(@RequestParam(name = "refreshToken")
+                                                      @ApiParam(value = REFRESH_TOKEN, example = REFRESH_TOKEN_EXAMPLE)
+                                                      String refreshToken) {
+        String newAccessToken = tokenService.issueNewAccessToken(refreshToken);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(newAccessToken);
+    }
+}

--- a/src/main/java/com/firstone/greenjangteo/user/domain/token/model/entity/RefreshToken.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/token/model/entity/RefreshToken.java
@@ -1,6 +1,7 @@
 package com.firstone.greenjangteo.user.domain.token.model.entity;
 
 
+import com.firstone.greenjangteo.user.security.JwtTokenProvider;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -34,5 +35,13 @@ public class RefreshToken {
 
     public static RefreshToken from(Long id, List<String> roles, String token) {
         return new RefreshToken(id, roles, token);
+    }
+
+    public String getTokenValue() {
+        return token;
+    }
+
+    public String createNewAccessToken(JwtTokenProvider jwtTokenProvider) {
+        return jwtTokenProvider.generateAccessToken(String.valueOf(userId), roles);
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/user/domain/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/token/repository/RefreshTokenRepository.java
@@ -3,5 +3,8 @@ package com.firstone.greenjangteo.user.domain.token.repository;
 import com.firstone.greenjangteo.user.domain.token.model.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String refreshTokenValue);
 }

--- a/src/main/java/com/firstone/greenjangteo/user/domain/token/service/TokenService.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/token/service/TokenService.java
@@ -13,6 +13,8 @@ public class TokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
+    private static final String INVALID_TOKEN_EXCEPTION_MESSAGE = "유효하지 않은 리프레시 토큰입니다. 전송된 토큰: ";
+
     public String issueAccessToken(User user) {
         String accessToken
                 = jwtTokenProvider.generateAccessToken(String.valueOf(user.getId()), user.getRoles().toStrings());
@@ -26,5 +28,15 @@ public class TokenService {
         refreshTokenRepository.save(RefreshToken.from(user.getId(), user.getRoles().toStrings(), refreshToken));
 
         return refreshToken;
+    }
+
+    public String issueNewAccessToken(String refreshTokenValue) {
+        RefreshToken refreshToken = getRefreshToken(refreshTokenValue);
+        return refreshToken.createNewAccessToken(jwtTokenProvider);
+    }
+
+    private RefreshToken getRefreshToken(String refreshTokenValue) {
+        return refreshTokenRepository.findByToken(refreshTokenValue)
+                .orElseThrow(() -> new IllegalArgumentException(INVALID_TOKEN_EXCEPTION_MESSAGE + refreshTokenValue));
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/user/domain/token/service/TokenService.java
+++ b/src/main/java/com/firstone/greenjangteo/user/domain/token/service/TokenService.java
@@ -13,7 +13,7 @@ public class TokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    private static final String INVALID_TOKEN_EXCEPTION_MESSAGE = "유효하지 않은 리프레시 토큰입니다. 전송된 토큰: ";
+    static final String INVALID_TOKEN_EXCEPTION_MESSAGE = "유효하지 않은 리프레시 토큰입니다. 전송된 토큰: ";
 
     public String issueAccessToken(User user) {
         String accessToken

--- a/src/test/java/com/firstone/greenjangteo/user/domain/token/controller/TokenControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/user/domain/token/controller/TokenControllerTest.java
@@ -1,0 +1,56 @@
+package com.firstone.greenjangteo.user.domain.token.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.firstone.greenjangteo.user.domain.token.service.TokenService;
+import com.firstone.greenjangteo.user.security.CustomAuthenticationEntryPoint;
+import com.firstone.greenjangteo.user.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = TokenController.class)
+class TokenControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TokenService tokenService;
+
+    @MockBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @DisplayName("올바른 리프레시 토큰 값을 입력하면 새로운 엑세스 토큰을 발급할 수 있다.")
+    @Test
+    @WithMockUser
+    void issueNewAccessToken() throws Exception {
+        // given
+        String REFRESH_TOKEN_VALUE = "refreshTokenExample";
+
+        when(tokenService.issueNewAccessToken(REFRESH_TOKEN_VALUE)).thenReturn("newAccessTokenExample");
+
+        // when, then
+        mockMvc.perform(post("/token")
+                        .queryParam("refreshToken", REFRESH_TOKEN_VALUE)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/user/domain/token/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/firstone/greenjangteo/user/domain/token/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.firstone.greenjangteo.user.domain.token.repository;
+
+import com.firstone.greenjangteo.user.domain.token.model.entity.RefreshToken;
+import com.firstone.greenjangteo.user.model.entity.User;
+import com.firstone.greenjangteo.user.security.JwtTokenProvider;
+import com.firstone.greenjangteo.user.testutil.UserTestObjectFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static com.firstone.greenjangteo.user.model.Role.ROLE_BUYER;
+import static com.firstone.greenjangteo.user.testutil.UserTestConstant.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class RefreshTokenRepositoryTest {
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @DisplayName("리프레시 토큰 값을 통해 리프레시 토큰 엔티티를 조회할 수 있다.")
+    @Test
+    void findByToken() {
+        // given
+        User user1 = UserTestObjectFactory.createUser(
+                1L, EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.toString())
+        );
+        User user2 = UserTestObjectFactory.createUser(
+                2L, EMAIL2, USERNAME2, PASSWORD2, passwordEncoder, FULL_NAME2, PHONE2, List.of(ROLE_BUYER.toString())
+        );
+
+        String refreshTokenValue1
+                = jwtTokenProvider.generateRefreshToken(user1.getId().toString(), user1.getRoles().toStrings());
+        String refreshTokenValue2
+                = jwtTokenProvider.generateRefreshToken(user2.getId().toString(), user2.getRoles().toStrings());
+
+        RefreshToken createdRefreshToken1 = RefreshToken.from(user1.getId(), user1.getRoles().toStrings(), refreshTokenValue1);
+        RefreshToken createdRefreshToken2 = RefreshToken.from(user2.getId(), user2.getRoles().toStrings(), refreshTokenValue2);
+        refreshTokenRepository.saveAll(List.of(createdRefreshToken1, createdRefreshToken2));
+
+        // when
+        RefreshToken foundRefreshToken1 = refreshTokenRepository.findByToken(refreshTokenValue1).get();
+        RefreshToken foundRefreshToken2 = refreshTokenRepository.findByToken(refreshTokenValue2).get();
+
+        // then
+        assertThat(foundRefreshToken1).isNotNull();
+        assertThat(foundRefreshToken2).isNotNull();
+        assertThat(foundRefreshToken1).isNotEqualTo(createdRefreshToken2);
+    }
+}

--- a/src/test/java/com/firstone/greenjangteo/user/domain/token/service/TokenServiceTest.java
+++ b/src/test/java/com/firstone/greenjangteo/user/domain/token/service/TokenServiceTest.java
@@ -1,7 +1,9 @@
 package com.firstone.greenjangteo.user.domain.token.service;
 
+import com.firstone.greenjangteo.user.domain.token.model.entity.RefreshToken;
 import com.firstone.greenjangteo.user.domain.token.repository.RefreshTokenRepository;
 import com.firstone.greenjangteo.user.model.entity.User;
+import com.firstone.greenjangteo.user.security.JwtTokenProvider;
 import com.firstone.greenjangteo.user.testutil.UserTestObjectFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,9 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.firstone.greenjangteo.user.domain.token.service.TokenService.INVALID_TOKEN_EXCEPTION_MESSAGE;
 import static com.firstone.greenjangteo.user.model.Role.ROLE_BUYER;
 import static com.firstone.greenjangteo.user.testutil.UserTestConstant.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -29,6 +33,9 @@ class TokenServiceTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     @DisplayName("엑세스 토큰을 발급할 수 있다.")
     @Test
@@ -47,7 +54,7 @@ class TokenServiceTest {
 
     @DisplayName("리프레시 토큰을 발급하고 저장할 수 있다.")
     @Test
-    void refreshAccessToken() {
+    void issueRefreshToken() {
         // given
         User user = UserTestObjectFactory.createUser(
                 1L, EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.toString())
@@ -60,5 +67,52 @@ class TokenServiceTest {
         // then
         assertThat(createdRefreshToken).isNotBlank();
         assertThat(foundRefreshToken).isEqualTo(createdRefreshToken);
+    }
+
+    @DisplayName("리프레시 토큰 값을 통해 새로운 엑세스 토큰을 발급할 수 있다.")
+    @Test
+    void issueNewAccessToken() {
+        // given
+        User user1 = UserTestObjectFactory.createUser(
+                1L, EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.toString())
+        );
+        User user2 = UserTestObjectFactory.createUser(
+                2L, EMAIL2, USERNAME2, PASSWORD2, passwordEncoder, FULL_NAME2, PHONE2, List.of(ROLE_BUYER.toString())
+        );
+
+        String refreshTokenValue1
+                = jwtTokenProvider.generateRefreshToken(user1.getId().toString(), user1.getRoles().toStrings());
+        String refreshTokenValue2
+                = jwtTokenProvider.generateRefreshToken(user2.getId().toString(), user2.getRoles().toStrings());
+
+        RefreshToken refreshToken1 = RefreshToken.from(user1.getId(), user1.getRoles().toStrings(), refreshTokenValue1);
+        RefreshToken refreshToken2 = RefreshToken.from(user2.getId(), user2.getRoles().toStrings(), refreshTokenValue2);
+        refreshTokenRepository.saveAll(List.of(refreshToken1, refreshToken2));
+
+        // when
+        String accessToken1 = tokenService.issueNewAccessToken(refreshTokenValue1);
+        String accessToken2 = tokenService.issueNewAccessToken(refreshTokenValue2);
+
+        // then
+        assertThat(accessToken1).isNotBlank();
+        assertThat(accessToken2).isNotBlank();
+        assertThat(accessToken1).isNotEqualTo(accessToken2);
+    }
+
+    @DisplayName("존재하지 않는 리프레시 토큰 값을 통해 엑세스 토큰을 발급하려 하면 IllegalArgumentException이 발생한다.")
+    @Test
+    void issueNewAccessTokenFromNonExistentRefreshTokenValue() {
+        // given
+        User user = UserTestObjectFactory.createUser(
+                1L, EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_BUYER.toString())
+        );
+
+        String refreshTokenValue
+                = jwtTokenProvider.generateRefreshToken(user.getId().toString(), user.getRoles().toStrings());
+
+        // when, then
+        assertThatThrownBy(() -> tokenService.issueNewAccessToken(refreshTokenValue))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(INVALID_TOKEN_EXCEPTION_MESSAGE + refreshTokenValue);
     }
 }

--- a/src/test/java/com/firstone/greenjangteo/user/domain/token/testutil/TokenTestObjectFactory.java
+++ b/src/test/java/com/firstone/greenjangteo/user/domain/token/testutil/TokenTestObjectFactory.java
@@ -1,0 +1,11 @@
+package com.firstone.greenjangteo.user.domain.token.testutil;
+
+import com.firstone.greenjangteo.user.domain.token.model.entity.RefreshToken;
+
+import java.util.List;
+
+public class TokenTestObjectFactory {
+    public static RefreshToken createRefreshToken(Long userId, List<String> roles, String token) {
+        return RefreshToken.from(userId, roles, token);
+    }
+}


### PR DESCRIPTION
## resolve #264

## 추가사항

## 프로덕션 코드
- 리프레시 토큰을 통한 엑세스 토큰 재발급 요청
- 엑세스 토큰 재발급 요청 비즈니스 로직
- 리프레시 토큰 값을 통한 리프레시 토큰 튜플 검색
- 잘못된 리프레시 토큰 값을 통한 검색 시 예외 처리
- 201 status code 반환

### 테스트 코드
- 엑세스 토큰 재발급 요청, 201 status code 응답
- 엑세스 토큰 재발급 요청 비즈니스 로직
- 리프레시 토큰 값을 통한 리프레시 토큰 튜플 검색
- 존재하지 않는 리프레시 토큰 값을 통한 검색 시 예외 처리