### PR TITLE
[#267] 프로젝트 전반적인 리팩토링

### DIFF
--- a/src/main/java/com/firstone/greenjangteo/aop/LoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/aop/LoggingAspect.java
@@ -26,9 +26,9 @@ public class LoggingAspect {
             = "execution(* com.firstone.greenjangteo..service.*.*(..)) && args(longValue, ..)";
 
     private static final String START
-            = "Beginning to '{}.{}' task by '{}: {}'";
+            = "Beginning to '{}.{}' task by {}: '{}'";
     private static final String END
-            = "'{}.{}' task was executed successfully by '{}: {}', ";
+            = "'{}.{}' task was executed successfully by {}: '{}', ";
 
     private static final String NO_VALUE_POINTCUT
             = "execution(* com.firstone.greenjangteo..service.*.*())";
@@ -40,16 +40,16 @@ public class LoggingAspect {
     private static final String USER_ID_REQUEST_DTO_POINTCUT
             = "execution(* com.firstone.greenjangteo..service.*.*(..)) && args(userIdRequestDto)";
     private static final String USER_ID_REQUEST_DTO_START
-            = "Beginning to '{}.{}' task by 'userId: {}', ";
+            = "Beginning to '{}.{}' task by userId: '{}', ";
     private static final String USER_ID_REQUEST_DTO_END
-            = "'{}.{}' task was executed successfully by 'userId: {}', ";
+            = "'{}.{}' task was executed successfully by userId: '{}', ";
 
     private static final String PAGEABLE_AND_ID_POINTCUT
             = "execution(* com.firstone.greenjangteo..service.*.*(..)) && args(pageable, longValue)";
     private static final String PAGEABLE_AND_ID_START
-            = "Beginning to '{}.{}' task by 'page: {}', '{}: {}'";
+            = "Beginning to '{}.{}' task by page: '{}', {}: '{}'";
     private static final String PAGEABLE_AND_ID_END
-            = "'{}.{}' task was executed successfully by 'page: {}', '{}: {}', ";
+            = "'{}.{}' task was executed successfully by page: '{}', {}: '{}', ";
 
     @Around(STRING_VALUE_POINTCUT)
     public Object logAroundForStringValue(ProceedingJoinPoint joinPoint, String stringValue) throws Throwable {

--- a/src/main/java/com/firstone/greenjangteo/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/firstone/greenjangteo/configuration/WebSecurityConfig.java
@@ -41,7 +41,7 @@ public class WebSecurityConfig extends GlobalMethodSecurityConfiguration {
                 .and()
                 .authorizeHttpRequests()
                 .antMatchers("/", "/swagger-ui/**", "/v2/api-docs", "/swagger-resources/**",
-                        "/**/signup", "/**/login", "/users")
+                        "/**/signup", "/**/login", "/users", "/token")
                 .permitAll()
                 .antMatchers(HttpMethod.GET, "/users/{userId}").permitAll()
                 .antMatchers(HttpMethod.GET, "/products/**").permitAll()

--- a/src/main/java/com/firstone/greenjangteo/coupon/aop/CouponLoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/coupon/aop/CouponLoggingAspect.java
@@ -24,21 +24,21 @@ public class CouponLoggingAspect {
     private static final String CREATE_COUPONS_START
             = "Beginning to '{}.{}' task by couponName: '{}'";
     private static final String CREATE_COUPONS_END
-            = "'{}.{}' task was executed successfully by 'couponName: {}', ";
+            = "'{}.{}' task was executed successfully by couponName: '{}', ";
 
     private static final String PROVIDE_COUPONS_TO_USER_POINTCUT
             = "execution(* com.firstone.greenjangteo.coupon.service.*.*(..)) && args(provideCouponsToUserRequestDto)";
     private static final String PROVIDE_COUPONS_TO_USER_START
             = "Beginning to '{}.{}' task by couponName: '{}', userId: '{}'";
     private static final String PROVIDE_COUPONS_TO_USER_END
-            = "'{}.{}' task was executed successfully by 'couponName: {}', userId: '{}', ";
+            = "'{}.{}' task was executed successfully by couponName: '{}', userId: '{}', ";
 
     private static final String PROVIDE_COUPONS_TO_USERS_POINTCUT
             = "execution(* com.firstone.greenjangteo.coupon.service.*.*(..)) && args(provideCouponsToUsersRequestDto)";
     private static final String PROVIDE_COUPONS_TO_USERS_START
             = "Beginning to '{}.{}' task by couponGroupId: '{}'";
     private static final String PROVIDE_COUPONS_TO_USERS_END
-            = "'{}.{}' task was executed successfully by 'couponGroupId: {}', ";
+            = "'{}.{}' task was executed successfully by couponGroupId: '{}', ";
 
     @Around(CREATE_COUPONS_POINTCUT)
     public Object logAroundForIssueCouponsRequestDto(ProceedingJoinPoint joinPoint,

--- a/src/main/java/com/firstone/greenjangteo/order/aop/OrderLoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/order/aop/OrderLoggingAspect.java
@@ -23,14 +23,14 @@ public class OrderLoggingAspect {
     private static final String ORDER_START
             = "Beginning to '{}.{}' task by sellerId: '{}', buyerId: '{}'";
     private static final String ORDER_END
-            = "'{}.{}' task was executed successfully by 'sellerId: {}', 'buyerId: {}', ";
+            = "'{}.{}' task was executed successfully by sellerId: '{}', buyerId: '{}', ";
 
     private static final String CART_ORDER_POINTCUT
             = "execution(* com.firstone.greenjangteo.order.service.*.*(..)) && args(cartOrderRequestDto)";
     private static final String CART_ORDER_START
             = "Beginning to '{}.{}' task by buyerId: '{}', cartId: '{}'";
     private static final String CART_ORDER_END
-            = "'{}.{}' task was executed successfully by 'buyerId: {}', 'cartId: {}', ";
+            = "'{}.{}' task was executed successfully by buyerId: '{}', cartId: '{}', ";
 
     @Around(ORDER_POINTCUT)
     public Object logAroundForOrderRequestDto(ProceedingJoinPoint joinPoint,

--- a/src/main/java/com/firstone/greenjangteo/order/dto/request/OrderProductRequestDto.java
+++ b/src/main/java/com/firstone/greenjangteo/order/dto/request/OrderProductRequestDto.java
@@ -15,7 +15,7 @@ import static com.firstone.greenjangteo.web.ApiConstant.ID_EXAMPLE;
 public class OrderProductRequestDto {
     private static final String PRODUCT_ID_VALUE = "상품 ID";
     private static final String QUANTITY_VALUE = "주문 수량";
-    static final String QUANTITY_EXAMPLE = "5";
+    private static final String QUANTITY_EXAMPLE = "5";
 
     @ApiModelProperty(value = PRODUCT_ID_VALUE, example = ID_EXAMPLE)
     private String productId;

--- a/src/main/java/com/firstone/greenjangteo/post/aop/PostLoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/post/aop/PostLoggingAspect.java
@@ -23,14 +23,14 @@ public class PostLoggingAspect {
     private static final String CREATE_POST_START
             = "Beginning to '{}.{}' task by userId: '{}', subject: '{}'";
     private static final String CREATE_POST_END
-            = "'{}.{}' task was executed successfully by 'userId: {}', subject: '{}', ";
+            = "'{}.{}' task was executed successfully by userId: '{}', subject: '{}', ";
 
     private static final String GET_ALL_POSTS_POINTCUT
             = "execution(* com.firstone.greenjangteo.post.service.*.*(..)) && args(pageable)";
     private static final String GET_ALL_POSTS_START
             = "Beginning to '{}.{}' task by page: '{}'";
     private static final String GET_ALL_POSTS_END
-            = "'{}.{}' task was executed successfully by 'page: {}', ";
+            = "'{}.{}' task was executed successfully by page: '{}', ";
 
     @Around(CREATE_POST_POINTCUT)
     public Object logAroundForPostRequestDto(ProceedingJoinPoint joinPoint,

--- a/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/domain/comment/service/CommentServiceImpl.java
@@ -23,7 +23,6 @@ import static com.firstone.greenjangteo.post.domain.comment.exception.message.In
 import static com.firstone.greenjangteo.post.domain.comment.exception.message.InconsistentExceptionMessage.INCONSISTENT_COMMENT_EXCEPTION_POST_ID;
 import static com.firstone.greenjangteo.post.domain.comment.exception.message.NotFoundExceptionMessage.COMMENTED_USER_ID_NOT_FOUND_EXCEPTION;
 import static com.firstone.greenjangteo.post.domain.comment.exception.message.NotFoundExceptionMessage.COMMENT_NOT_FOUND_EXCEPTION;
-import static com.firstone.greenjangteo.post.exception.message.NotFoundExceptionMessage.POSTED_USER_ID_NOT_FOUND_EXCEPTION;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 import static org.springframework.transaction.annotation.Isolation.REPEATABLE_READ;
 

--- a/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/post/service/PostServiceImpl.java
@@ -113,6 +113,8 @@ public class PostServiceImpl implements PostService {
             return;
         }
 
-        throw new EntityNotFoundException(POST_NOT_FOUND_EXCEPTION + postId + POSTED_USER_ID_NOT_FOUND_EXCEPTION + userId);
+        throw new EntityNotFoundException(
+                POST_NOT_FOUND_EXCEPTION + postId + POSTED_USER_ID_NOT_FOUND_EXCEPTION + userId
+        );
     }
 }

--- a/src/main/java/com/firstone/greenjangteo/user/aop/UserLoggingAspect.java
+++ b/src/main/java/com/firstone/greenjangteo/user/aop/UserLoggingAspect.java
@@ -23,14 +23,14 @@ public class UserLoggingAspect {
     private static final String SIGN_UP_START
             = "Beginning to '{}.{}' task by email: '{}', username: '{}'";
     private static final String SIGN_UP_END
-            = "'{}.{}' task was executed successfully by 'email: {}', 'username: {}', ";
+            = "'{}.{}' task was executed successfully by email: '{}', username: '{}', ";
 
     private static final String SIGN_IN_POINTCUT
             = "execution(* com.firstone.greenjangteo.user.service.*.*(..)) && args(signInForm)";
     private static final String SIGN_IN_START
             = "Beginning to '{}.{}' task by email or username: '{}'";
     private static final String SIGN_IN_END
-            = "'{}.{}' task was executed successfully by 'email or username: {}', ";
+            = "'{}.{}' task was executed successfully by email or username: '{}', ";
 
     @Around(SIGN_UP_POINTCUT)
     public Object logAroundForSignUpForm(ProceedingJoinPoint joinPoint, SignUpForm signUpForm) throws Throwable {

--- a/src/main/java/com/firstone/greenjangteo/user/model/entity/User.java
+++ b/src/main/java/com/firstone/greenjangteo/user/model/entity/User.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.firstone.greenjangteo.audit.BaseEntity;
 import com.firstone.greenjangteo.coupon.model.entity.Coupon;
+import com.firstone.greenjangteo.post.model.entity.Post;
 import com.firstone.greenjangteo.user.dto.AddressDto;
 import com.firstone.greenjangteo.user.form.SignUpForm;
 import com.firstone.greenjangteo.user.model.Email;
@@ -75,6 +76,9 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.LAZY)
     private List<Coupon> coupons;
+
+    @OneToMany(mappedBy = "user", cascade = REMOVE, fetch = FetchType.LAZY)
+    private List<Post> posts;
 
 
     @Builder

--- a/src/main/java/com/firstone/greenjangteo/user/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/user/service/AuthenticationServiceImpl.java
@@ -88,8 +88,8 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
 
     @Override
     @Transactional(isolation = REPEATABLE_READ, timeout = 10)
-    public void updateEmail(Long id, EmailRequestDto emailRequestDto) {
-        User user = userService.getUser(id);
+    public void updateEmail(Long userId, EmailRequestDto emailRequestDto) {
+        User user = userService.getUser(userId);
 
         validatePassword(user.getPassword(), emailRequestDto.getPassword());
         checkEmail(emailRequestDto.getEmail());
@@ -99,8 +99,8 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
 
     @Override
     @Transactional(isolation = REPEATABLE_READ, timeout = 10)
-    public void updatePhone(Long id, PhoneRequestDto phoneRequestDto) {
-        User user = userService.getUser(id);
+    public void updatePhone(Long userId, PhoneRequestDto phoneRequestDto) {
+        User user = userService.getUser(userId);
 
         validatePassword(user.getPassword(), phoneRequestDto.getPassword());
         checkPhone(phoneRequestDto.getPhone());
@@ -109,8 +109,8 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
     }
 
     @Override
-    public void updatePassword(Long id, PasswordUpdateRequestDto passwordUpdateRequestDto) {
-        User user = userService.getUser(id);
+    public void updatePassword(Long userId, PasswordUpdateRequestDto passwordUpdateRequestDto) {
+        User user = userService.getUser(userId);
 
         validatePassword(user.getPassword(), passwordUpdateRequestDto.getCurrentPassword());
         user.updatePassword(passwordUpdateRequestDto.getPasswordToChange(), passwordEncoder);
@@ -119,13 +119,13 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
     }
 
     @Override
-    public void deleteUser(long id, DeleteRequestDto deleteRequestDto) {
-        User user = userService.getUser(id);
+    public void deleteUser(long userId, DeleteRequestDto deleteRequestDto) {
+        User user = userService.getUser(userId);
 
         validatePassword(user.getPassword(), deleteRequestDto.getPassword());
 
         if (user.getRoles().containSeller()) {
-            storeService.deleteStore(id);
+            storeService.deleteStore(userId);
         }
         userRepository.delete(user);
     }

--- a/src/main/java/com/firstone/greenjangteo/user/service/UserServiceImpl.java
+++ b/src/main/java/com/firstone/greenjangteo/user/service/UserServiceImpl.java
@@ -23,14 +23,14 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
-    public User getUser(Long id) {
-        return userRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(USER_ID_NOT_FOUND_EXCEPTION + id));
+    public User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_ID_NOT_FOUND_EXCEPTION + userId));
     }
 
     @Override
-    public void updateAddress(Long id, AddressDto addressDto) {
-        User user = getUser(id);
+    public void updateAddress(Long userId, AddressDto addressDto) {
+        User user = getUser(userId);
 
         user.updateAddress(addressDto);
     }

--- a/src/test/java/com/firstone/greenjangteo/post/controller/PostControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/post/controller/PostControllerTest.java
@@ -1,6 +1,7 @@
 package com.firstone.greenjangteo.post.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.firstone.greenjangteo.post.domain.comment.service.CommentService;
 import com.firstone.greenjangteo.post.domain.image.dto.ImageRequestDto;
 import com.firstone.greenjangteo.post.domain.image.testutil.ImageTestObjectFactory;
 import com.firstone.greenjangteo.post.domain.view.model.entity.View;
@@ -54,6 +55,9 @@ class PostControllerTest {
 
     @MockBean
     private PostService postService;
+
+    @MockBean
+    private CommentService commentService;
 
     @MockBean
     private ViewService viewService;
@@ -178,7 +182,7 @@ class PostControllerTest {
 
     @DisplayName("게시글 ID와 회원 ID를 전송해 게시글을 수정할 수 있다.")
     @Test
-    @WithMockUser
+    @WithMockUser(username = BUYER_ID, roles = {"BUYER"})
     void updatePost() throws Exception {
         // given
         User user = mock(User.class);

--- a/src/test/java/com/firstone/greenjangteo/user/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/firstone/greenjangteo/user/controller/AuthenticationControllerTest.java
@@ -89,9 +89,7 @@ class AuthenticationControllerTest {
     @WithMockUser
     void signInUser() throws Exception {
         // given
-        SignUpForm signUpForm = UserTestObjectFactory.enterUserForm
-                (EMAIL1, USERNAME1, PASSWORD1, PASSWORD1, FULL_NAME1,
-                        PHONE1, List.of(ROLE_SELLER.toString()));
+        SignInForm signInForm = new SignInForm(EMAIL1, PASSWORD1);
 
         User user = UserTestObjectFactory.createUser(
                 EMAIL1, USERNAME1, PASSWORD1, passwordEncoder, FULL_NAME1, PHONE1, List.of(ROLE_SELLER.toString())
@@ -99,11 +97,10 @@ class AuthenticationControllerTest {
 
         when(authenticationService.signInUser(any(SignInForm.class)))
                 .thenReturn(user);
-
         // when, then
         mockMvc.perform(post("/users/login")
                         .with(csrf())
-                        .content(objectMapper.writeValueAsString(signUpForm))
+                        .content(objectMapper.writeValueAsString(signInForm))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk());


### PR DESCRIPTION
## resolve #267

## 변경사항

### 회원
- User 엔티티에 게시판 목록에 대한 참조 추가
- AuthenticationServiceImpl 클래스와 UserServiceImpl 클래스의 일부 id 변수명을 userId로 변경
- AuthenticationControllerTest 클래스의 signInUser 메서드에서 SignUpForm 객체를 SignInForm 객체로 변경

### 토큰
- 사용자 인증 대상에서 /token 리소스 제외

### 주문
- OrderProductRequestDto 클래스의 QUANTITY_EXAMPLE 상수의 접근 제한자를 default로 변경

### 게시판
- PostServiceImpl 클래스의 EntityNotFound 예외 처리 부분 개행
- PostControllerTest 클래스
    - CommentService에 대한 참조 추가
    - WithMocker 어노테이션에 username과 roles 추가
- PostServiceTest 클래스
    - deletePost 메서드의 매개변수 변경
    - deletePostWithWrongPostOrUserId 메서드 추가

### 댓글
- 사용하지 않는 import문 제거

### 공통
- 각 도메인의 AOP 로그 출력 형식 통일

## 배포
- [ ] 확인